### PR TITLE
chore: pin @types/chai to an exact version

### DIFF
--- a/common-ts/bun.lock
+++ b/common-ts/bun.lock
@@ -22,7 +22,7 @@
       "devDependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@jest/globals": "29.3.1",
-        "@types/chai": "^4.3.11",
+        "@types/chai": "4.3.20",
         "@types/mocha": "10.0.4",
         "@types/sinon": "21.0.1",
         "chai": "4.3.10",

--- a/common-ts/package.json
+++ b/common-ts/package.json
@@ -153,7 +153,7 @@
 	"devDependencies": {
 		"@coral-xyz/anchor": "0.29.0",
 		"@jest/globals": "29.3.1",
-		"@types/chai": "^4.3.11",
+		"@types/chai": "4.3.20",
 		"@types/mocha": "10.0.4",
 		"@types/sinon": "21.0.1",
 		"chai": "4.3.10",


### PR DESCRIPTION
Part of a workspace-wide pass tightening dependency pinning.

## What

`common-ts/package.json`: `@types/chai` `^4.3.11` → `4.3.20`.

## Why

This was the last loose semver range in `common-ts`. `bunfig.toml` already sets `exact = true`, so the manifest was inconsistent with the repo policy.

## No dependency change

`4.3.20` is the version **already resolved** in `common-ts/bun.lock`, so the installed tree is unchanged. The lockfile diff is a single spec string; the resolved entry and its integrity hash are untouched.

## Verification

`bun install --frozen-lockfile` in `common-ts/` exits 0 (`Checked 859 installs across 674 packages (no changes)`).