### PR TITLE
ci: run the dependency gate from the base branch

### DIFF
--- a/.github/workflows/new-dependency-gate.yml
+++ b/.github/workflows/new-dependency-gate.yml
@@ -9,15 +9,15 @@ name: New dependency gate
 # velocity-exchange/dependency-gate, reached via $GITHUB_ACTION_PATH, so a pull
 # request cannot weaken the check that is inspecting it by editing a script here.
 #
-# FOLLOW-UP once this is on master: switch the trigger to `pull_request_target`
-# and set `require-pull-request-target: true`. Under `pull_request` the workflow
-# file itself comes from the pull request, so a pull request can still edit or
-# delete its own gate; the action warns about this on every run. That switch is
-# not possible before merge, because `pull_request_target` runs the base
-# branch's copy of the workflow and there is none until this lands.
+# This runs on `pull_request_target`, so the workflow file itself always comes
+# from the base branch: a pull request cannot edit or delete its own gate.
+# The action never checks out the pull request head; it reads head lockfiles
+# as bytes through the GitHub contents API at a pinned head SHA and parses
+# them with the base branch's parser, so the usual privileged-token hazard of
+# `pull_request_target` does not apply here.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:
@@ -38,3 +38,5 @@ jobs:
         with:
           # Every published package's lockfile, plus the workspace root.
           lockfiles: bun.lock common-ts/bun.lock icons/bun.lock posthog-types/bun.lock react/bun.lock
+          # Fail loudly if this workflow is ever downgraded back to `pull_request`.
+          require-pull-request-target: true


### PR DESCRIPTION
## What

Switches `new-dependency-gate.yml` from `pull_request` to `pull_request_target`, and adds `require-pull-request-target: true` to the `velocity-exchange/dependency-gate` action's `with:` block.

## Why

Under `pull_request`, GitHub evaluates the workflow file from the pull request's own copy. That means a pull request could edit or delete the gate meant to inspect it, in the same diff that adds the dependency. `pull_request_target` reads the workflow from the base branch instead, closing that hole.

This switch was not possible until now: `pull_request_target` only takes effect once the workflow exists on the base branch, and the gate only just landed on `master`. The header comment on the workflow said as much (a "FOLLOW-UP once this is on master" note); this PR is that follow-up, so the comment is rewritten rather than left stale.

`require-pull-request-target: true` makes the action fail loudly if the trigger is ever downgraded back to `pull_request` in the future.

## Why the usual `pull_request_target` risk does not apply here

`pull_request_target` normally trades one hazard (a PR can edit the workflow that gates it) for another (running untrusted PR code with a privileged `GITHUB_TOKEN`). That second hazard does not apply to this action: it never checks out the PR head. It reads head lockfiles as bytes through the GitHub contents API at a pinned head SHA, and parses them with the base branch's own parser. `actions/checkout` is left as is, no `ref:` added, so the checkout stays on the base branch, which is what keeps this safe.

## What to expect from this PR's own checks

This PR will show **no dependency-gate check at all**, and that is expected, not a failure:

- GitHub evaluates `pull_request` triggers from the PR head, which (after this change) no longer declares that trigger.
- GitHub evaluates `pull_request_target` triggers from the base branch, which does not have this workflow yet, since this PR is what adds it.

So neither the old nor the new trigger fires on this PR itself. The gate becomes active, from the base branch, starting with the next PR opened after this one merges.

## Changes

- `.github/workflows/new-dependency-gate.yml` only:
  - `on: pull_request` -> `on: pull_request_target` (same `types` list, unchanged)
  - added `require-pull-request-target: true` under the `dependency-gate` action's `with:`
  - rewrote the header comment that described the pre-merge limitation
- No change to the action pin, permissions, `lockfiles` value, runner, or the `actions/checkout` step (no `ref:` added, `fetch-depth: 0` unchanged).
