### PR TITLE
feat: convert slot-denominated trading logic to wall-clock intents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,13 @@ jobs:
         with:
           working-directory: ./common-ts
 
+      - name: No deprecated slot-time constant
+        run: |
+          if grep -rn "SLOT_TIME_ESTIMATE_MS" src tests; then
+            echo "SLOT_TIME_ESTIMATE_MS is deprecated: read the live slot duration from State instead."
+            exit 1
+          fi
+
       - name: Typecheck
         run: bun run typecheck
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,13 +54,6 @@ jobs:
         with:
           working-directory: ./common-ts
 
-      - name: No deprecated slot-time constant
-        run: |
-          if grep -rn "SLOT_TIME_ESTIMATE_MS" src tests; then
-            echo "SLOT_TIME_ESTIMATE_MS is deprecated: read the live slot duration from State instead."
-            exit 1
-          fi
-
       - name: Typecheck
         run: bun run typecheck
 

--- a/common-ts/CLAUDE.md
+++ b/common-ts/CLAUDE.md
@@ -50,8 +50,10 @@ Solana's slot time is dropping from 400ms to 200ms through feature gates, so slo
 are integers compared against the live slot; wall-clock is ms converted at the read
 site; never write a slot length. This package does not resolve the live duration
 itself: every function whose behavior depends on slot length takes a `SlotDurationMs`
-parameter, and the outermost caller resolves it from `State` via the SDK's
-`activeSlotDurationFromState`. Convert with the SDK's `math/time` helpers
+parameter, and the outermost caller resolves it with the SDK's
+`currentSlotDuration(client, slot)` (or `currentSlotClock` to branch on
+`isLive`), which falls back to the 400ms baseline on a dead slot feed or an
+unsubscribed client. Convert with the SDK's `math/time` helpers
 (`millisFromSlots`, `msToSlotsCeilNum`, `slotsToMsNum`), ceiling user-protection
 budgets and flooring risk ceilings. `SLOT_TIME_ESTIMATE_MS` is deprecated and CI
 fails if it reappears.

--- a/common-ts/CLAUDE.md
+++ b/common-ts/CLAUDE.md
@@ -44,6 +44,18 @@ are internal-only (verify with `rg` across `src`) are free to refactor or delete
 - Real deduplication of large near-identical blocks is welcome; collapsing three short
   similar lines into a clever abstraction is not.
 
+## Slots and wall-clock time
+
+Solana's slot time is dropping from 400ms to 200ms through feature gates, so slots
+are integers compared against the live slot; wall-clock is ms converted at the read
+site; never write a slot length. This package does not resolve the live duration
+itself: every function whose behavior depends on slot length takes a `SlotDurationMs`
+parameter, and the outermost caller resolves it from `State` via the SDK's
+`activeSlotDurationFromState`. Convert with the SDK's `math/time` helpers
+(`millisFromSlots`, `msToSlotsCeilNum`, `slotsToMsNum`), ceiling user-protection
+budgets and flooring risk ceilings. `SLOT_TIME_ESTIMATE_MS` is deprecated and CI
+fails if it reappears.
+
 ## Type safety
 
 `strictNullChecks` is currently **off** in `tsconfig.json` (there's a standing TODO to

--- a/common-ts/bun.lock
+++ b/common-ts/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@solana/spl-token": "0.4.14",
         "@solana/web3.js": "1.98.0",
-        "@velocity-exchange/sdk": "0.10.0",
+        "@velocity-exchange/sdk": "0.14.0",
         "bcryptjs-react": "2.4.6",
         "cerializr": "3.1.4",
         "dotenv": "17.4.2",
@@ -391,7 +391,7 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.56.0", "", { "dependencies": { "@typescript-eslint/types": "8.56.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg=="],
 
-    "@velocity-exchange/sdk": ["@velocity-exchange/sdk@0.10.0", "", { "dependencies": { "@anchor-lang/core": "1.0.1", "@coral-xyz/anchor": "npm:@anchor-lang/core@1.0.1", "@coral-xyz/anchor-29": "npm:@coral-xyz/anchor@0.29.0", "@msgpack/msgpack": "3.1.2", "@noble/hashes": "1.7.1", "@pythnetwork/client": "2.5.3", "@pythnetwork/price-service-sdk": "1.7.1", "@pythnetwork/pyth-lazer-sdk": "6.0.0", "@solana/buffer-layout": "4.0.1", "@solana/spl-token": "0.4.13", "@solana/web3.js": "1.98.0", "@triton-one/yellowstone-grpc": "5.0.5", "anchor-bankrun": "0.5.0", "bn.js": "^5.2.0", "bs58": "4.0.1", "gill": "0.10.2", "nanoid": "3.3.4", "node-cache": "5.1.2", "node-fetch": "2.7.0", "solana-bankrun": "0.4.0", "strict-event-emitter-types": "2.0.0", "tweetnacl": "1.0.3", "tweetnacl-util": "0.15.1", "uuid": "8.3.2", "ws": "8.18.1", "yargs": "17.7.2", "zod": "4.0.17", "zstddec": "0.1.0" }, "optionalDependencies": { "helius-laserstream": "0.1.8" } }, "sha512-RiE8B4kdjejk0SUh3fLN2eaEeaV0k8ohhMWOYwOYFYHFGXbaZdmH9BSXLUR+/GEIMLndaQXzrpZyS+mXAgFkkA=="],
+    "@velocity-exchange/sdk": ["@velocity-exchange/sdk@0.14.0", "", { "dependencies": { "@anchor-lang/core": "1.0.1", "@coral-xyz/anchor": "npm:@anchor-lang/core@1.0.1", "@coral-xyz/anchor-29": "npm:@coral-xyz/anchor@0.29.0", "@msgpack/msgpack": "3.1.2", "@noble/hashes": "1.7.1", "@pythnetwork/client": "2.5.3", "@pythnetwork/price-service-sdk": "1.7.1", "@pythnetwork/pyth-lazer-sdk": "6.0.0", "@solana/buffer-layout": "4.0.1", "@solana/spl-token": "0.4.13", "@solana/web3.js": "1.98.0", "@triton-one/yellowstone-grpc": "5.0.5", "anchor-bankrun": "0.5.0", "bn.js": "5.2.3", "bs58": "4.0.1", "gill": "0.10.2", "nanoid": "3.3.4", "node-cache": "5.1.2", "node-fetch": "2.7.0", "solana-bankrun": "0.4.0", "strict-event-emitter-types": "2.0.0", "tweetnacl": "1.0.3", "tweetnacl-util": "0.15.1", "uuid": "8.3.2", "ws": "8.18.1", "yargs": "17.7.2", "zod": "4.0.17", "zstddec": "0.1.0" }, "optionalDependencies": { "helius-laserstream": "0.1.8" } }, "sha512-gcK9cGO5qUPDj3LjcN10bam+vpR2Q1AfB2YX/gUBvIQrZZ/pAOZa/euCR3YLAaJAS3T5HTqbjrDUMje5Exk0fg=="],
 
     "@vue/compiler-core": ["@vue/compiler-core@3.5.28", "", { "dependencies": { "@babel/parser": "^7.29.0", "@vue/shared": "3.5.28", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-kviccYxTgoE8n6OCw96BNdYlBg2GOWfBuOW4Vqwrt7mSKWKwFVvI8egdTltqRgITGPsTFYtKYfxIG8ptX2PJHQ=="],
 
@@ -1427,6 +1427,8 @@
 
     "@velocity-exchange/sdk/@solana/spl-token": ["@solana/spl-token@0.4.13", "", { "dependencies": { "@solana/buffer-layout": "^4.0.0", "@solana/buffer-layout-utils": "^0.2.0", "@solana/spl-token-group": "^0.0.7", "@solana/spl-token-metadata": "^0.1.6", "buffer": "^6.0.3" }, "peerDependencies": { "@solana/web3.js": "^1.95.5" } }, "sha512-cite/pYWQZZVvLbg5lsodSovbetK/eA24gaR0eeUeMuBAMNrT8XFCwaygKy0N2WSg3gSyjjNpIeAGBAKZaY/1w=="],
 
+    "@velocity-exchange/sdk/bn.js": ["bn.js@5.2.3", "", {}, "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w=="],
+
     "@velocity-exchange/sdk/nanoid": ["nanoid@3.3.4", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="],
 
     "@velocity-exchange/sdk/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
@@ -1720,6 +1722,8 @@
     "@solana/transaction-confirmation/@solana/transactions/@solana/nominal-types": ["@solana/nominal-types@2.3.0", "", { "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA=="],
 
     "@velocity-exchange/sdk/@coral-xyz/anchor/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@velocity-exchange/sdk/@coral-xyz/anchor/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
 
     "@velocity-exchange/sdk/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 

--- a/common-ts/bun.lock
+++ b/common-ts/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@solana/spl-token": "0.4.14",
         "@solana/web3.js": "1.98.0",
-        "@velocity-exchange/sdk": "0.14.0",
+        "@velocity-exchange/sdk": "0.15.0",
         "bcryptjs-react": "2.4.6",
         "cerializr": "3.1.4",
         "dotenv": "17.4.2",
@@ -391,7 +391,7 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.56.0", "", { "dependencies": { "@typescript-eslint/types": "8.56.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg=="],
 
-    "@velocity-exchange/sdk": ["@velocity-exchange/sdk@0.14.0", "", { "dependencies": { "@anchor-lang/core": "1.0.1", "@coral-xyz/anchor": "npm:@anchor-lang/core@1.0.1", "@coral-xyz/anchor-29": "npm:@coral-xyz/anchor@0.29.0", "@msgpack/msgpack": "3.1.2", "@noble/hashes": "1.7.1", "@pythnetwork/client": "2.5.3", "@pythnetwork/price-service-sdk": "1.7.1", "@pythnetwork/pyth-lazer-sdk": "6.0.0", "@solana/buffer-layout": "4.0.1", "@solana/spl-token": "0.4.13", "@solana/web3.js": "1.98.0", "@triton-one/yellowstone-grpc": "5.0.5", "anchor-bankrun": "0.5.0", "bn.js": "5.2.3", "bs58": "4.0.1", "gill": "0.10.2", "nanoid": "3.3.4", "node-cache": "5.1.2", "node-fetch": "2.7.0", "solana-bankrun": "0.4.0", "strict-event-emitter-types": "2.0.0", "tweetnacl": "1.0.3", "tweetnacl-util": "0.15.1", "uuid": "8.3.2", "ws": "8.18.1", "yargs": "17.7.2", "zod": "4.0.17", "zstddec": "0.1.0" }, "optionalDependencies": { "helius-laserstream": "0.1.8" } }, "sha512-gcK9cGO5qUPDj3LjcN10bam+vpR2Q1AfB2YX/gUBvIQrZZ/pAOZa/euCR3YLAaJAS3T5HTqbjrDUMje5Exk0fg=="],
+    "@velocity-exchange/sdk": ["@velocity-exchange/sdk@0.15.0", "", { "dependencies": { "@anchor-lang/core": "1.0.1", "@coral-xyz/anchor": "npm:@anchor-lang/core@1.0.1", "@coral-xyz/anchor-29": "npm:@coral-xyz/anchor@0.29.0", "@msgpack/msgpack": "3.1.2", "@noble/hashes": "1.7.1", "@pythnetwork/client": "2.5.3", "@pythnetwork/price-service-sdk": "1.7.1", "@pythnetwork/pyth-lazer-sdk": "6.0.0", "@solana/buffer-layout": "4.0.1", "@solana/spl-token": "0.4.13", "@solana/web3.js": "1.98.0", "@triton-one/yellowstone-grpc": "5.0.5", "anchor-bankrun": "0.5.0", "bn.js": "5.2.3", "bs58": "4.0.1", "gill": "0.10.2", "nanoid": "3.3.4", "node-cache": "5.1.2", "node-fetch": "2.7.0", "solana-bankrun": "0.4.0", "strict-event-emitter-types": "2.0.0", "tweetnacl": "1.0.3", "tweetnacl-util": "0.15.1", "uuid": "8.3.2", "ws": "8.18.1", "yargs": "17.7.2", "zod": "4.0.17", "zstddec": "0.1.0" }, "optionalDependencies": { "helius-laserstream": "0.1.8" } }, "sha512-qLUI1eW1N8rqSiVLXlSBRH+nrs0LXWpefS8nDGhoMpxQ6X4Z+FhUCH1meh4l97dji/aLuN0c6PtC7ULpmgpxmg=="],
 
     "@vue/compiler-core": ["@vue/compiler-core@3.5.28", "", { "dependencies": { "@babel/parser": "^7.29.0", "@vue/shared": "3.5.28", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-kviccYxTgoE8n6OCw96BNdYlBg2GOWfBuOW4Vqwrt7mSKWKwFVvI8egdTltqRgITGPsTFYtKYfxIG8ptX2PJHQ=="],
 

--- a/common-ts/package.json
+++ b/common-ts/package.json
@@ -20,7 +20,7 @@
 	"dependencies": {
 		"@solana/spl-token": "0.4.14",
 		"@solana/web3.js": "1.98.0",
-		"@velocity-exchange/sdk": "0.14.0",
+		"@velocity-exchange/sdk": "0.15.0",
 		"bcryptjs-react": "2.4.6",
 		"cerializr": "3.1.4",
 		"dotenv": "17.4.2",

--- a/common-ts/package.json
+++ b/common-ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@velocity-exchange/common",
-	"version": "0.5.0",
+	"version": "0.4.1",
 	"description": "Common functions for Velocity",
 	"main": "./lib/index.js",
 	"types": "./lib/index.d.ts",

--- a/common-ts/package.json
+++ b/common-ts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@velocity-exchange/common",
-	"version": "0.4.1",
+	"version": "0.5.0",
 	"description": "Common functions for Velocity",
 	"main": "./lib/index.js",
 	"types": "./lib/index.d.ts",
@@ -20,7 +20,7 @@
 	"dependencies": {
 		"@solana/spl-token": "0.4.14",
 		"@solana/web3.js": "1.98.0",
-		"@velocity-exchange/sdk": "0.10.0",
+		"@velocity-exchange/sdk": "0.14.0",
 		"bcryptjs-react": "2.4.6",
 		"cerializr": "3.1.4",
 		"dotenv": "17.4.2",

--- a/common-ts/src/actions/actionHelpers/accountDeletionHelpers.ts
+++ b/common-ts/src/actions/actionHelpers/accountDeletionHelpers.ts
@@ -3,7 +3,9 @@ import {
 	BN,
 	VelocityClient,
 	IDLE_TIME,
+	millisFromSecs,
 	millisFromSlots,
+	QUOTE_PRECISION,
 	SlotDurationMs,
 	User,
 	UserStats,
@@ -13,6 +15,12 @@ import {
 	positionIsAvailable,
 } from '@velocity-exchange/sdk';
 import { TransactionInstruction } from '@solana/web3.js';
+
+/**
+ * The non-accelerated idle threshold (one week) from `validate_user_is_idle`.
+ * The SDK only exports the accelerated hour as `IDLE_TIME`.
+ */
+const IDLE_TIME_UNACCELERATED = millisFromSecs(604_800);
 
 type AccountDeletionStep =
 	| 'askToCloseAllPositionsOrdersBorrows'
@@ -234,6 +242,10 @@ const tryDeleteUserAccount = async (
  * The program gates idleness on wall-clock, so the elapsed slot delta is
  * converted at the live duration rather than assumed; the remaining time is
  * rounded up so the estimate never under-states the wait.
+ *
+ * The threshold itself is equity-dependent, mirroring `validate_user_is_idle`:
+ * an hour below $1000 of equity, a week at or above it. Reading the hour
+ * unconditionally under-states the wait by a week for a funded account.
  */
 export const getIdleWaitTimeMinutes = (
 	user: User,
@@ -244,10 +256,18 @@ export const getIdleWaitTimeMinutes = (
 
 	const inactiveSlots = Math.max(currentSlot - lastActiveSlot.toNumber(), 0);
 
+	const { totalAssetValue, totalLiabilityValue } =
+		user.getSpotMarketAssetAndLiabilityValue();
+	const equity = totalAssetValue.sub(totalLiabilityValue);
+
+	const idleAfter = equity.lt(QUOTE_PRECISION.muln(1000))
+		? IDLE_TIME
+		: IDLE_TIME_UNACCELERATED;
+
 	const remainingMs = Math.max(
-		IDLE_TIME.sub(
-			millisFromSlots(new BN(inactiveSlots), slotDuration)
-		).toNumber(),
+		idleAfter
+			.sub(millisFromSlots(new BN(inactiveSlots), slotDuration))
+			.toNumber(),
 		0
 	);
 

--- a/common-ts/src/actions/actionHelpers/accountDeletionHelpers.ts
+++ b/common-ts/src/actions/actionHelpers/accountDeletionHelpers.ts
@@ -243,9 +243,15 @@ const tryDeleteUserAccount = async (
  * converted at the live duration rather than assumed; the remaining time is
  * rounded up so the estimate never under-states the wait.
  *
- * The threshold itself is equity-dependent, mirroring `validate_user_is_idle`:
- * an hour below $1000 of equity, a week at or above it. Reading the hour
- * unconditionally under-states the wait by a week for a funded account.
+ * The threshold is equity-dependent: `handle_update_user_idle` accelerates to
+ * an hour below $1000 of equity and holds a week at or above it, so reading the
+ * hour unconditionally under-states a funded account's wait.
+ *
+ * The equity here is spot-only, where the program's `calculate_user_equity`
+ * also carries a perp term. They agree wherever this estimate is meaningful,
+ * because `PerpPosition::is_available` gates both the program's equity walk and
+ * its idle validation: any perp position that would move the equity also blocks
+ * idleness outright, so the wait is not a question that has an answer yet.
  */
 export const getIdleWaitTimeMinutes = (
 	user: User,

--- a/common-ts/src/actions/actionHelpers/accountDeletionHelpers.ts
+++ b/common-ts/src/actions/actionHelpers/accountDeletionHelpers.ts
@@ -2,8 +2,9 @@ import {
 	ACCOUNT_AGE_DELETION_CUTOFF_SECONDS,
 	BN,
 	VelocityClient,
-	IDLE_TIME_SLOTS,
-	SLOT_TIME_ESTIMATE_MS,
+	IDLE_TIME,
+	millisFromSlots,
+	SlotDurationMs,
 	User,
 	UserStats,
 	UserStatsAccount,
@@ -92,14 +93,18 @@ type CanBeDeletedState =
 const getAccountCanBeDeletedInstantly = (
 	user: User,
 	userStatsAccount: UserStatsAccount,
-	currentSlot: number
+	currentSlot: number,
+	slotDuration: SlotDurationMs
 ): CanBeDeletedState => {
 	const statsAccountIsPastDeletionCutoff =
 		getStatsAccountIsPastDeletionCutoff(userStatsAccount);
 
 	const userIsIdle = user.getUserAccountOrThrow().idle;
 
-	const userCanBeMarkedIdle = user.canMakeIdle(new BN(currentSlot));
+	const userCanBeMarkedIdle = user.canMakeIdle(
+		new BN(currentSlot),
+		slotDuration
+	);
 
 	const accountHasOpenPerpSpotOrOrders = accountHasOpenPositionsOrOrders(user);
 
@@ -132,7 +137,8 @@ const getAccountCanBeDeletedInstantly = (
 const getAccountDeletionStepsToTake = (
 	user: User,
 	userStatsAccount: UserStatsAccount,
-	currentSlot: number
+	currentSlot: number,
+	slotDuration: SlotDurationMs
 ): AccountDeletionStep[] => {
 	const userAccount = user.getUserAccountOrThrow();
 	const statsAccountIsPastDeletionCutoff =
@@ -158,7 +164,7 @@ const getAccountDeletionStepsToTake = (
 	}
 
 	// Account can be marked idle and then deleted
-	const canBeMarkedIdle = user.canMakeIdle(new BN(currentSlot));
+	const canBeMarkedIdle = user.canMakeIdle(new BN(currentSlot), slotDuration);
 
 	if (canBeMarkedIdle) {
 		return ['sendTriggerAccountIdleIx', 'sendAccountDeletionIx'];
@@ -180,12 +186,14 @@ const tryDeleteUserAccount = async (
 	velocityClient: VelocityClient,
 	user: User,
 	userStatsAccount: UserStatsAccount,
-	latestSlot: number
+	latestSlot: number,
+	slotDuration: SlotDurationMs
 ) => {
 	const canBeDeleted = getAccountCanBeDeletedInstantly(
 		user,
 		userStatsAccount,
-		latestSlot
+		latestSlot,
+		slotDuration
 	);
 
 	if (canBeDeleted === 'no' || canBeDeleted === 'no-wait-for-idle') {
@@ -222,23 +230,28 @@ const tryDeleteUserAccount = async (
 	return txSig;
 };
 
-export const getIdleWaitTimeMinutes = (user: User, currentSlot: number) => {
+/**
+ * The program gates idleness on wall-clock, so the elapsed slot delta is
+ * converted at the live duration rather than assumed; the remaining time is
+ * rounded up so the estimate never under-states the wait.
+ */
+export const getIdleWaitTimeMinutes = (
+	user: User,
+	currentSlot: number,
+	slotDuration: SlotDurationMs
+) => {
 	const lastActiveSlot = user.getUserAccountOrThrow().lastActiveSlot;
 
-	const inactiveAccountTime = Math.max(
-		currentSlot - lastActiveSlot.toNumber(),
+	const inactiveSlots = Math.max(currentSlot - lastActiveSlot.toNumber(), 0);
+
+	const remainingMs = Math.max(
+		IDLE_TIME.sub(
+			millisFromSlots(new BN(inactiveSlots), slotDuration)
+		).toNumber(),
 		0
 	);
 
-	const slotsToWait = IDLE_TIME_SLOTS - inactiveAccountTime;
-
-	const secondsPerSlot = SLOT_TIME_ESTIMATE_MS / 1000;
-
-	const timeEstimateSeconds = slotsToWait * secondsPerSlot;
-
-	const minutesEstimate = Math.ceil(timeEstimateSeconds / 60);
-
-	return minutesEstimate;
+	return Math.ceil(remainingMs / 60_000);
 };
 
 export const ACCOUNT_DELETION_HELPERS = {

--- a/common-ts/src/drift/Velocity/clients/AuthorityVelocity/VelocityOperations/index.ts
+++ b/common-ts/src/drift/Velocity/clients/AuthorityVelocity/VelocityOperations/index.ts
@@ -450,6 +450,7 @@ export class VelocityOperations {
 					const swiftOrderResult = await createOpenPerpMarketOrder({
 						velocityClient: this.velocityClient,
 						user,
+						slotDuration: params.slotDuration,
 						assetType: params.assetType,
 						useSwift: true,
 						swiftOptions: {
@@ -481,6 +482,7 @@ export class VelocityOperations {
 					const result = await createOpenPerpMarketOrder({
 						velocityClient: this.velocityClient,
 						user,
+						slotDuration: params.slotDuration,
 						assetType: params.assetType,
 						marketIndex: params.marketIndex,
 						direction: params.direction,
@@ -513,6 +515,7 @@ export class VelocityOperations {
 					const swiftOrderResult = await createOpenPerpNonMarketOrder({
 						velocityClient: this.velocityClient,
 						user,
+						slotDuration: params.slotDuration,
 						direction: params.direction,
 						marketIndex: params.marketIndex,
 						amount: amountBN,
@@ -547,6 +550,7 @@ export class VelocityOperations {
 					const txn = await createOpenPerpNonMarketOrder({
 						velocityClient: this.velocityClient,
 						user,
+						slotDuration: params.slotDuration,
 						direction: params.direction,
 						marketIndex: params.marketIndex,
 						amount: amountBN,
@@ -576,6 +580,7 @@ export class VelocityOperations {
 				const txn = await createOpenPerpNonMarketOrder({
 					velocityClient: this.velocityClient,
 					user,
+					slotDuration: params.slotDuration,
 					direction: params.direction,
 					marketIndex: params.marketIndex,
 					amount: amountBN,
@@ -599,6 +604,7 @@ export class VelocityOperations {
 				const txn = await createOpenPerpNonMarketOrder({
 					velocityClient: this.velocityClient,
 					user,
+					slotDuration: params.slotDuration,
 					direction: params.direction,
 					marketIndex: params.marketIndex,
 					amount: amountBN,

--- a/common-ts/src/drift/Velocity/clients/AuthorityVelocity/VelocityOperations/types.ts
+++ b/common-ts/src/drift/Velocity/clients/AuthorityVelocity/VelocityOperations/types.ts
@@ -3,6 +3,7 @@ import {
 	PositionDirection,
 	PostOnlyParams,
 	PublicKey,
+	SlotDurationMs,
 	SwapQuote,
 } from '@velocity-exchange/sdk';
 import { OptionalAuctionParamsRequestInputs } from '../../../../base/actions/trade/openPerpOrder/dlobServer';
@@ -58,6 +59,8 @@ export interface CreateRevenueShareEscrowParams {
 export type PerpOrderParams = {
 	subAccountId: number;
 	marketIndex: number;
+	/** Live slot duration, resolved by the caller from `State` */
+	slotDuration: SlotDurationMs;
 	direction: PositionDirection;
 	assetType: 'base' | 'quote';
 	size: BigNum;

--- a/common-ts/src/drift/Velocity/clients/CentralServerVelocity/index.ts
+++ b/common-ts/src/drift/Velocity/clients/CentralServerVelocity/index.ts
@@ -25,6 +25,7 @@ import {
 	PublicKey,
 	SettlePnlMode,
 	SpotMarketConfig,
+	SlotDurationMs,
 	SwapMode,
 	TxParams,
 	UnifiedSwapClient,
@@ -887,6 +888,7 @@ export class CentralServerVelocity {
 					assetType: params.assetType ?? 'base',
 					reduceOnly: true,
 					dlobServerHttpUrl: this._velocityEndpoints.dlobServerHttpUrl,
+					slotDuration: params.slotDuration,
 					positionMaxLeverage: 0,
 					mainSignerOverride: signingAuthority,
 					placeAndTake: params.placeAndTake,
@@ -1010,6 +1012,7 @@ export class CentralServerVelocity {
 					assetType: params.assetType ?? 'base',
 					reduceOnly: true,
 					dlobServerHttpUrl: this._velocityEndpoints.dlobServerHttpUrl,
+					slotDuration: params.slotDuration,
 					positionMaxLeverage: 0,
 					mainSignerOverride: signingAuthority,
 					placeAndTake: params.placeAndTake,
@@ -1075,7 +1078,8 @@ export class CentralServerVelocity {
 			maxTs?: BN;
 			policy?: number;
 			positionMaxLeverage?: number;
-		}
+		},
+		slotDuration: SlotDurationMs
 	): Promise<VersionedTransaction | Transaction> {
 		return this.velocityClientContextWrapper(
 			userAccountPublicKey,
@@ -1085,6 +1089,7 @@ export class CentralServerVelocity {
 					user,
 					orderId,
 					editOrderParams,
+					slotDuration,
 				});
 
 				return editOrderTxn;

--- a/common-ts/src/drift/Velocity/clients/CentralServerVelocity/types.ts
+++ b/common-ts/src/drift/Velocity/clients/CentralServerVelocity/types.ts
@@ -1,4 +1,9 @@
-import { BN, PositionDirection, TxParams } from '@velocity-exchange/sdk';
+import {
+	BN,
+	PositionDirection,
+	SlotDurationMs,
+	TxParams,
+} from '@velocity-exchange/sdk';
 import { WithTxnParams } from '../../../base/types';
 import { OpenPerpMarketOrderBaseParams } from '../../../base/actions/trade/openPerpOrder/openPerpMarketOrder';
 import { OpenPerpNonMarketOrderBaseParams } from '../../../base/actions/trade/openPerpOrder/openPerpNonMarketOrder';
@@ -84,6 +89,8 @@ export interface CentralServerGetCloseAndWithdrawIsolatedPerpPositionTxnParams {
 	baseAssetAmount: BN;
 	/** Direction of the close order (opposite of position). */
 	direction: PositionDirection;
+	/** Live slot duration, resolved by the caller from `State` */
+	slotDuration: SlotDurationMs;
 	/** If true, includes collateral transfer ix after close order (will withdraw available isolated margin; amount is fill-dependent). */
 	withdrawCollateralAfterClose?: boolean;
 	/** If true and withdrawCollateralAfterClose, prepends settle PnL ix. */
@@ -112,6 +119,8 @@ export interface CentralServerGetCloseAndWithdrawIsolatedPerpPositionToWalletTxn
 	baseAssetAmount: BN;
 	/** Direction of the close order (opposite of position). */
 	direction: PositionDirection;
+	/** Live slot duration, resolved by the caller from `State` */
+	slotDuration: SlotDurationMs;
 	/**
 	 * Amount to withdraw (QUOTE_PRECISION). When omitted or larger than available,
 	 * the SDK withdraws all. Pass a specific amount for partial withdrawal.

--- a/common-ts/src/drift/base/actions/trade/editOrder.ts
+++ b/common-ts/src/drift/base/actions/trade/editOrder.ts
@@ -5,6 +5,7 @@ import {
 	OrderType,
 	PositionDirection,
 	PostOnlyParams,
+	SlotDurationMs,
 	User,
 } from '@velocity-exchange/sdk';
 import {
@@ -63,6 +64,8 @@ export interface CreateEditOrderIxParams {
 	user: User;
 	orderId: number;
 	editOrderParams: EditOrderParams;
+	/** Live slot duration, resolved by the caller from `State` */
+	slotDuration: SlotDurationMs;
 	mainSignerOverride?: PublicKey;
 	limitAuctionOrderConfig?: LimitOrderParamsOrderConfig & {
 		limitAuction: LimitAuctionConfig;
@@ -88,6 +91,7 @@ export const createEditOrderIx = async (
 		editOrderParams,
 		mainSignerOverride,
 		limitAuctionOrderConfig,
+		slotDuration,
 	} = params;
 	const currentOrder = user.getOrder(orderId);
 
@@ -118,6 +122,7 @@ export const createEditOrderIx = async (
 			postOnly: currentOrder.postOnly,
 			orderConfig: limitAuctionOrderConfig,
 			positionMaxLeverage: editOrderParams.positionMaxLeverage ?? 0,
+			slotDuration,
 		});
 
 		finalEditOrderParams = {

--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/auction.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/auction.ts
@@ -10,10 +10,11 @@ import {
 	VelocityClient,
 	User,
 	PositionDirection,
+	SlotDurationMs,
 } from '@velocity-exchange/sdk';
 import { getPerpAuctionDuration } from '../../../../../utils/orders/flags';
 import { getLimitAuctionParams } from '../../../../../utils/trading/auction';
-import { DEFAULT_LIMIT_AUCTION_DURATION } from '../../../constants/auction';
+import { getDefaultLimitAuctionDurationSlots } from '../../../constants/auction';
 import { ENUM_UTILS } from '../../../../../utils';
 import invariant from 'tiny-invariant';
 import { fetchAuctionOrderParams } from './dlobServer';
@@ -32,6 +33,7 @@ export const getLimitAuctionOrderParams = async ({
 	postOnly = PostOnlyParams.NONE,
 	orderConfig,
 	onAuctionParamsFetched,
+	slotDuration,
 }: {
 	velocityClient: VelocityClient;
 	user: User;
@@ -47,6 +49,8 @@ export const getLimitAuctionOrderParams = async ({
 		limitAuction: LimitAuctionConfig;
 	};
 	onAuctionParamsFetched?: AuctionParamsFetchedCallback;
+	/** Live slot duration, resolved by the caller from `State` */
+	slotDuration: SlotDurationMs;
 }): Promise<OptionalOrderParams> => {
 	const { orderParams } = await fetchAuctionOrderParams({
 		velocityClient,
@@ -61,6 +65,7 @@ export const getLimitAuctionOrderParams = async ({
 		optionalAuctionParamsInputs:
 			orderConfig.limitAuction.optionalLimitAuctionParams,
 		onAuctionParamsFetched: onAuctionParamsFetched,
+		slotDuration,
 	});
 
 	const isPerp = ENUM_UTILS.match(marketType, MarketType.PERP);
@@ -69,7 +74,7 @@ export const getLimitAuctionOrderParams = async ({
 	invariant(orderParams.auctionStartPrice, 'Auction start price not found');
 
 	let oraclePriceBands: [BN, BN] | undefined = undefined;
-	let auctionDuration = DEFAULT_LIMIT_AUCTION_DURATION;
+	let auctionDuration = getDefaultLimitAuctionDurationSlots(slotDuration);
 
 	if (isPerp) {
 		const perpMarketAccount = velocityClient.getPerpMarketAccount(marketIndex);
@@ -84,7 +89,8 @@ export const getLimitAuctionOrderParams = async ({
 		auctionDuration = getPerpAuctionDuration(
 			orderConfig.limitPrice.sub(orderParams.auctionStartPrice).abs(),
 			orderConfig.limitAuction.oraclePrice,
-			perpMarketAccount.contractTier
+			perpMarketAccount.contractTier,
+			slotDuration
 		);
 	}
 

--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/dlobServer/index.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/dlobServer/index.ts
@@ -16,6 +16,7 @@ import {
 	createL2Levels,
 	DEFAULT_TOP_OF_BOOK_QUOTE_AMOUNTS,
 	MAJORS_TOP_OF_BOOK_QUOTE_AMOUNTS,
+	SlotDurationMs,
 } from '@velocity-exchange/sdk';
 import { ENUM_UTILS } from '../../../../../../utils';
 import { calculateSpreadBidAskMark } from '../../../../../../utils/math';
@@ -47,7 +48,7 @@ import {
 	getPriceObject,
 	deriveMarketOrderParams,
 } from '../../../../../../utils/trading/auction';
-import { DEFAULT_MARKET_AUCTION_DURATION } from '../../../../constants/auction';
+import { getDefaultMarketAuctionDurationSlots } from '../../../../constants/auction';
 import invariant from 'tiny-invariant';
 import { logger } from '../../../../../../utils/logger';
 
@@ -79,6 +80,8 @@ interface RegularOrderParams {
 	direction: PositionDirection;
 	amount: BN;
 	dlobServerHttpUrl: string;
+	/** Live slot duration, resolved by the caller from `State` */
+	slotDuration: SlotDurationMs;
 	reduceOnly?: boolean;
 	optionalAuctionParamsInputs?: OptionalAuctionParamsRequestInputs;
 	dynamicSlippageConfig?: DynamicSlippageConfig;
@@ -354,6 +357,7 @@ export async function fetchAuctionOrderParamsFromL2({
 	optionalAuctionParamsInputs = {},
 	velocityClient,
 	dynamicSlippageConfig,
+	slotDuration,
 }: RegularOrderParams): Promise<FetchAuctionOrderParamsResult> {
 	const marketId = new MarketId(marketIndex, marketType);
 	const baseAmount =
@@ -384,6 +388,7 @@ export async function fetchAuctionOrderParamsFromL2({
 		reduceOnly,
 		optionalAuctionParamsInputs,
 		dynamicSlippageConfig,
+		slotDuration,
 		source: 'l2',
 	});
 }
@@ -405,6 +410,7 @@ export function deriveFromL2Inputs({
 	reduceOnly,
 	optionalAuctionParamsInputs,
 	dynamicSlippageConfig,
+	slotDuration,
 	source,
 }: {
 	l2Data: L2OrderBook;
@@ -418,6 +424,7 @@ export function deriveFromL2Inputs({
 	reduceOnly?: boolean;
 	optionalAuctionParamsInputs: OptionalAuctionParamsRequestInputs;
 	dynamicSlippageConfig?: DynamicSlippageConfig;
+	slotDuration: SlotDurationMs;
 	source: AuctionOrderParamsMeta['source'];
 }): FetchAuctionOrderParamsResult {
 	const priceImpactData = calculatePriceImpactFromL2(
@@ -476,7 +483,7 @@ export function deriveFromL2Inputs({
 		// signed-message order is rejected by the swift server as InvalidOrderAuction.
 		auctionDuration:
 			optionalAuctionParamsInputs.auctionDuration ??
-			DEFAULT_MARKET_AUCTION_DURATION,
+			getDefaultMarketAuctionDurationSlots(slotDuration),
 		auctionStartPriceOffset:
 			optionalAuctionParamsInputs.auctionStartPriceOffset ?? 0,
 		auctionEndPriceOffset:
@@ -537,6 +544,7 @@ export async function deriveAuctionParamsFromVamm({
 	reduceOnly,
 	optionalAuctionParamsInputs = {},
 	dynamicSlippageConfig,
+	slotDuration,
 }: RegularOrderParams): Promise<FetchAuctionOrderParamsResult> {
 	invariant(
 		ENUM_UTILS.match(marketType, MarketType.PERP),
@@ -564,6 +572,7 @@ export async function deriveAuctionParamsFromVamm({
 			marketIndex < 3
 				? MAJORS_TOP_OF_BOOK_QUOTE_AMOUNTS
 				: DEFAULT_TOP_OF_BOOK_QUOTE_AMOUNTS,
+		slotDuration,
 	});
 	const l2Data: L2OrderBook = {
 		bids: createL2Levels(vammGen.getL2Bids(), VAMM_L2_NUM_ORDERS),
@@ -603,6 +612,7 @@ export async function deriveAuctionParamsFromVamm({
 		reduceOnly,
 		optionalAuctionParamsInputs: bufferedInputs,
 		dynamicSlippageConfig,
+		slotDuration,
 		source: 'vamm',
 	});
 }

--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpMarketOrder/index.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpMarketOrder/index.ts
@@ -10,6 +10,7 @@ import {
 	RevenueShareEscrowAccount,
 	fetchRevenueShareEscrowAccount,
 	escrowHasReferrer,
+	SlotDurationMs,
 } from '@velocity-exchange/sdk';
 import {
 	PublicKey,
@@ -54,6 +55,8 @@ export interface OpenPerpMarketOrderBaseParams {
 	direction: PositionDirection;
 	amount: BN;
 	dlobServerHttpUrl: string;
+	/** Live slot duration, resolved by the caller from `State` */
+	slotDuration: SlotDurationMs;
 	reduceOnly?: boolean;
 	// mainly used for UI order identification
 	userOrderId?: number;
@@ -148,6 +151,7 @@ async function prepSwiftMarketOrderData(params: OpenPerpMarketOrderBaseParams) {
 		amount,
 		reduceOnly,
 		dlobServerHttpUrl,
+		slotDuration,
 		optionalAuctionParamsInputs,
 		userOrderId = 0,
 		callbacks,
@@ -166,6 +170,7 @@ async function prepSwiftMarketOrderData(params: OpenPerpMarketOrderBaseParams) {
 		direction,
 		amount,
 		dlobServerHttpUrl,
+		slotDuration,
 		optionalAuctionParamsInputs,
 		reduceOnly,
 		onAuctionParamsFetched: callbacks?.onAuctionParamsFetched,
@@ -198,6 +203,7 @@ export async function createSwiftMarketOrder(
 		positionMaxLeverage,
 		marginMode,
 		builderParams,
+		slotDuration,
 	} = params;
 
 	const resolvedDeposits = resolveIsolatedPositionDepositsWithOverride(
@@ -222,6 +228,7 @@ export async function createSwiftMarketOrder(
 		userAccountPubKey: user.userAccountPublicKey,
 		marketIndex,
 		userSigningSlotBuffer: swiftOptions.userSigningSlotBuffer ?? 0,
+		slotDuration,
 		swiftOptions,
 		orderParams: {
 			main: orderParams,
@@ -263,6 +270,7 @@ export async function createSwiftMarketOrderMessage(
 		builderParams,
 		isDelegate = false,
 		userSigningSlotBuffer,
+		slotDuration,
 	} = params;
 
 	const resolvedDeposits = resolveIsolatedPositionDepositsWithOverride(
@@ -287,6 +295,7 @@ export async function createSwiftMarketOrderMessage(
 		userAccountPubKey: user.userAccountPublicKey,
 		marketIndex,
 		userSigningSlotBuffer: userSigningSlotBuffer ?? 0,
+		slotDuration,
 		isDelegate,
 		orderParams: {
 			main: orderParams,
@@ -321,6 +330,7 @@ export const createPlaceAndTakePerpMarketOrderIx = async ({
 	callbacks,
 	takerEscrow,
 	builderParams,
+	slotDuration,
 }: Omit<
 	OpenPerpMarketOrderBaseParams,
 	'marginMode' | 'isolatedPositionDepositsOverride'
@@ -351,6 +361,7 @@ export const createPlaceAndTakePerpMarketOrderIx = async ({
 				amount,
 				reduceOnly,
 				dlobServerHttpUrl,
+				slotDuration,
 				optionalAuctionParamsInputs,
 				onAuctionParamsFetched: callbacks?.onAuctionParamsFetched,
 			}),
@@ -458,6 +469,7 @@ export const createOpenPerpMarketOrderIxs = async ({
 	isolatedPositionDepositsOverride,
 	callbacks,
 	builderParams,
+	slotDuration,
 }: OpenPerpMarketOrderBaseParams): Promise<TransactionInstruction[]> => {
 	if (!amount || amount.isZero()) {
 		throw new Error('Amount must be greater than zero');
@@ -546,6 +558,7 @@ export const createOpenPerpMarketOrderIxs = async ({
 				mainSignerOverride,
 				positionMaxLeverage,
 				builderParams,
+				slotDuration,
 			});
 			allIxs.push(placeAndTakeIx);
 		} catch (e) {
@@ -566,6 +579,7 @@ export const createOpenPerpMarketOrderIxs = async ({
 			direction,
 			amount,
 			dlobServerHttpUrl,
+			slotDuration,
 			optionalAuctionParamsInputs,
 			reduceOnly,
 			onAuctionParamsFetched: callbacks?.onAuctionParamsFetched,

--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpNonMarketOrder/index.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/openPerpNonMarketOrder/index.ts
@@ -7,6 +7,7 @@ import {
 	OptionalOrderParams,
 	PositionDirection,
 	OrderType,
+	SlotDurationMs,
 } from '@velocity-exchange/sdk';
 import {
 	PublicKey,
@@ -50,6 +51,8 @@ export interface OpenPerpNonMarketOrderBaseParams extends Omit<
 > {
 	velocityClient: VelocityClient;
 	user: User;
+	/** Live slot duration, resolved by the caller from `State` */
+	slotDuration: SlotDurationMs;
 	// Either new approach
 	amount?: BN;
 	assetType?: 'base' | 'quote';
@@ -166,6 +169,7 @@ export const createOpenPerpNonMarketOrderIxs = async (
 		mainSignerOverride,
 		isolatedPositionDepositsOverride,
 		builderParams,
+		slotDuration,
 	} = params;
 	// Support both new (amount + assetType) and legacy (baseAssetAmount) approaches
 	const finalBaseAssetAmount = resolveBaseAssetAmount({
@@ -293,6 +297,7 @@ export const createOpenPerpNonMarketOrderIxs = async (
 						orderConfig.limitAuction.usePlaceAndTake.auctionDurationPercentage,
 					takerEscrow: orderConfig.limitAuction.usePlaceAndTake.takerEscrow,
 					builderParams,
+					slotDuration,
 				});
 				allIxs.push(placeAndTakeIx);
 				createdPlaceAndTakeIx = true;
@@ -497,6 +502,7 @@ export const createSwiftLimitOrder = async (
 		userAccountPubKey: user.userAccountPublicKey,
 		marketIndex,
 		userSigningSlotBuffer: swiftOptions.userSigningSlotBuffer ?? 0,
+		slotDuration: params.slotDuration,
 		swiftOptions,
 		orderParams: {
 			main: orderParams,
@@ -557,6 +563,7 @@ export const createSwiftLimitOrderMessage = async (
 		userAccountPubKey: user.userAccountPublicKey,
 		marketIndex,
 		userSigningSlotBuffer: userSigningSlotBuffer ?? 0,
+		slotDuration: params.slotDuration,
 		isDelegate,
 		orderParams: {
 			main: orderParams,

--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/openSwiftOrder/index.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/openSwiftOrder/index.ts
@@ -530,19 +530,6 @@ export const sendSwiftOrder = ({
 };
 
 /**
- * Computes the timing parameters for a SWIFT order:
- * - slotsTillAuctionEnd: how many slots until the auction is considered ended
- * - signingDeadlineSlot: the absolute slot the signature must land before
- * - expirationTimeMs: the same window in ms, a backstop for a dead slot feed
- *
- * For market orders, auction duration + signing buffer is used directly.
- * For non-market orders, a minimum is enforced because limit auctions can have
- * very small durations but the order is still valid after the auction ends.
- *
- * The deadline is anchored on the prep `currentSlot`, not on the order's own
- * slot, because `slotsTillAuctionEnd` already includes the signing buffer.
- */
-/**
  * The signing window for a prepared order. `signingDeadlineSlot` is the
  * authoritative bound: `expirationTimeMs` is the same window converted at the
  * live duration, a backstop for when the slot feed is dead. Consumers showing
@@ -555,6 +542,21 @@ export type SwiftOrderTiming = {
 	expirationTimeMs: number;
 };
 
+/**
+ * Computes the timing parameters for a SWIFT order:
+ * - slotsTillAuctionEnd: how many slots until the auction is considered ended
+ * - signingDeadlineSlot: the absolute slot the signature must land before
+ * - expirationTimeMs: the same window in ms, a backstop for a dead slot feed
+ *
+ * For market orders, auction duration + signing buffer is used directly. For
+ * non-market orders a minimum is enforced, because a limit auction can be very
+ * short and the wallet prompt still needs a usable budget. That minimum governs
+ * the confirmation timeout only; it is not a placement deadline, since the
+ * program stops placing the order once the auction window has passed.
+ *
+ * The deadline is anchored on the prep `currentSlot`, not on the order's own
+ * slot, because both windows here are measured from prep time.
+ */
 const computeSwiftOrderTiming = (
 	mainOrderParams: OptionalOrderParams,
 	userSigningSlotBuffer: number,
@@ -577,16 +579,20 @@ const computeSwiftOrderTiming = (
 				)
 		: minimumNonAuctionSlots;
 
-	// The minimum floor can exceed a very short auction, which would put the
-	// deadline at or past the auction end and let the guard pass an order that
-	// can no longer fill. Cap it one slot short of the end so the deadline is
-	// always strictly inside the window. No-op for the durations in use today.
+	// The program stops placing the order once `order_slot + auction_duration`
+	// has passed, and `order_slot` is the auction start, i.e. the prep slot plus
+	// the signing buffer. `slotsTillAuctionEnd` carries a floor that can exceed
+	// that bound, so clamping against it would leave the deadline past the point
+	// the order can still be placed. Clamp against the chain's bound instead.
+	const onChainMaxSlotOffset =
+		userSigningSlotBuffer + (mainOrderParams.auctionDuration ?? 0);
+
 	const signingWindowSlots = Math.min(
 		Math.max(
 			slotsTillAuctionEnd - SWIFT_ORDER_SIGNING_EXPIRATION_BUFFER_SLOTS,
 			MINIMUM_SWIFT_ORDER_SIGNING_EXPIRATION_BUFFER_SLOTS
 		),
-		slotsTillAuctionEnd - 1
+		onChainMaxSlotOffset - 1
 	);
 
 	return {

--- a/common-ts/src/drift/base/actions/trade/openPerpOrder/openSwiftOrder/index.ts
+++ b/common-ts/src/drift/base/actions/trade/openPerpOrder/openSwiftOrder/index.ts
@@ -3,15 +3,17 @@ import {
 	OrderType,
 	SignedMsgOrderParamsDelegateMessage,
 	SignedMsgOrderParamsMessage,
-	SLOT_TIME_ESTIMATE_MS,
 } from '@velocity-exchange/sdk';
 import {
 	BN,
 	VelocityClient,
 	generateSignedMsgUuid,
 	getOrderParams,
+	msToSlotsCeilNum,
 	OptionalOrderParams,
 	PublicKey,
+	SlotDurationMs,
+	slotsToMsNum,
 } from '@velocity-exchange/sdk';
 import { ENUM_UTILS } from '../../../../../../utils';
 import { getSwiftConfirmationTimeoutMs } from '../../../../../../utils/signedMsgs';
@@ -30,20 +32,28 @@ import { convertLeverageToMarginRatio } from '../../../../../../utils/trading/le
 import { Connection } from '@solana/web3.js';
 
 /**
- * Buffer slots to account for signing of message by the user (default: 7 slots ~3 second, assumes user have to approves the signing in a UI wallet).
+ * Time allowed for the user to approve the signing prompt in a wallet UI, before
+ * the auction starts. Converted to actual slots at the live slot duration.
  */
-export const USER_SIGNING_MESSAGE_BUFFER_SLOTS = 7;
+export const USER_SIGNING_MESSAGE_BUFFER_MS = 2_800;
 
 /**
- * Orders without auction require a higher buffer (kink of the SWIFT server handling non-auction orders)
+ * Whole approval budget for orders without an auction (kink of the SWIFT server
+ * handling non-auction orders); enforced on chain, so it ceils.
  */
-export const MINIMUM_SWIFT_NON_AUCTION_ORDER_SIGNING_EXPIRATION_BUFFER_SLOTS = 35;
+export const MINIMUM_SWIFT_NON_AUCTION_ORDER_SIGNING_BUDGET_MS = 14_000;
 
 /**
  * Buffer slots from the end of the auction to prevent the signing of the order message.
  */
 export const SWIFT_ORDER_SIGNING_EXPIRATION_BUFFER_SLOTS = 5;
 export const MINIMUM_SWIFT_ORDER_SIGNING_EXPIRATION_BUFFER_SLOTS = 5;
+
+/**
+ * Wall-clock cadence at which the slot feed is polled while the wallet prompt is
+ * open. A poll interval, not a slot length.
+ */
+const SIGNING_DEADLINE_POLL_INTERVAL_MS = 250;
 
 export interface SwiftOrderOptions {
 	wallet: {
@@ -59,6 +69,12 @@ export interface SwiftOrderOptions {
 	userSigningSlotBuffer?: number;
 	isDelegate?: boolean;
 	/**
+	 * Live chain slot, polled while the wallet prompt is open so the signing guard
+	 * fires on the real deadline. Return 0 (or omit) for a dead feed, which falls
+	 * back to the wall-clock timer.
+	 */
+	slotSource?: () => number;
+	/**
 	 * Multiplier for the SWIFT confirmation timeout (after sending SWIFT order). Default is 1.
 	 */
 	confirmationMultiplier?: number;
@@ -66,7 +82,8 @@ export interface SwiftOrderOptions {
 		onOrderParamsMessagePrepped?: (
 			orderParamsMessage:
 				| SignedMsgOrderParamsMessage
-				| SignedMsgOrderParamsDelegateMessage
+				| SignedMsgOrderParamsDelegateMessage,
+			timing: SwiftOrderTiming
 		) => void;
 		onSigningExpiry?: (
 			orderParamsMessage:
@@ -126,6 +143,8 @@ export interface SwiftOrderMessage {
 	marketIndex: number;
 	/** Number of slots till the auction ends (used for confirmation timeout) */
 	slotsTillAuctionEnd: number;
+	/** Absolute slot after which the order must no longer be signed */
+	signingDeadlineSlot: number;
 	/** Time in milliseconds before the signing window expires */
 	expirationTimeMs: number;
 }
@@ -144,6 +163,8 @@ interface PrepSwiftOrderParams {
 	};
 	/** Current blockchain slot number */
 	currentSlot: number;
+	/** Live slot duration, resolved by the caller from `State` */
+	slotDuration: SlotDurationMs;
 	/** Whether this is a delegate order */
 	isDelegate: boolean;
 	/** Order parameters including main order and optional stop loss/take profit */
@@ -213,6 +234,7 @@ export const prepSwiftOrder = ({
 	velocityClient,
 	takerUserAccount,
 	currentSlot,
+	slotDuration,
 	isDelegate,
 	orderParams,
 	userSigningSlotBuffer,
@@ -235,16 +257,22 @@ export const prepSwiftOrder = ({
 	});
 
 	if (!userSigningSlotBuffer) {
-		userSigningSlotBuffer = mainOrderParams.auctionDuration
-			? USER_SIGNING_MESSAGE_BUFFER_SLOTS
-			: MINIMUM_SWIFT_NON_AUCTION_ORDER_SIGNING_EXPIRATION_BUFFER_SLOTS;
+		userSigningSlotBuffer = msToSlotsCeilNum(
+			mainOrderParams.auctionDuration
+				? USER_SIGNING_MESSAGE_BUFFER_MS
+				: MINIMUM_SWIFT_NON_AUCTION_ORDER_SIGNING_BUDGET_MS,
+			slotDuration
+		);
 	}
 
 	// if it is not an auction order, there should be a minimum buffer used
 	if (!mainOrderParams.auctionDuration) {
 		userSigningSlotBuffer = Math.max(
 			userSigningSlotBuffer,
-			MINIMUM_SWIFT_NON_AUCTION_ORDER_SIGNING_EXPIRATION_BUFFER_SLOTS
+			msToSlotsCeilNum(
+				MINIMUM_SWIFT_NON_AUCTION_ORDER_SIGNING_BUDGET_MS,
+				slotDuration
+			)
 		);
 	}
 
@@ -336,20 +364,26 @@ interface SignOrderMsgParams {
 	};
 	/** Hex-encoded swift order message to sign */
 	hexEncodedSwiftOrderMessage: Uint8Array;
+	/** Absolute slot after which the order must no longer be signed */
+	signingDeadlineSlot: number;
 	/** Time in milliseconds till the auction expires */
 	expirationTimeMs: number;
+	/** Live chain slot; 0 or omitted means the feed is dead */
+	slotSource?: () => number;
 	/** Callback function called when the auction expires */
 	onExpired?: () => void;
 }
 
 /**
  * Signs a swift order message with slot expiration monitoring.
- * Continuously monitors the current slot and rejects with AuctionSlotExpiredError
- * if the auction slot expires before signing is complete.
+ * The real deadline is a slot, so the live slot feed is the authority; the
+ * wall-clock timer is only a backstop for a dead feed.
  *
  * @param wallet - Wallet instance with message signing capability
  * @param hexEncodedSwiftOrderMessage - Hex-encoded swift order message to sign
+ * @param signingDeadlineSlot - Absolute slot after which the order must no longer be signed
  * @param expirationTimeMs - Time in milliseconds till the auction expires
+ * @param slotSource - Live chain slot, polled while the prompt is open
  * @param onExpired - Callback function called when the auction expires
  *
  * @returns Promise resolving to the signed message as Uint8Array
@@ -358,10 +392,13 @@ interface SignOrderMsgParams {
 export const signSwiftOrderMsg = async ({
 	wallet,
 	hexEncodedSwiftOrderMessage,
+	signingDeadlineSlot,
 	expirationTimeMs,
+	slotSource,
 	onExpired,
 }: SignOrderMsgParams): Promise<Uint8Array> => {
 	let timeoutId: ReturnType<typeof setTimeout> | undefined;
+	let intervalId: ReturnType<typeof setInterval> | undefined;
 
 	try {
 		// Sign the message
@@ -370,10 +407,21 @@ export const signSwiftOrderMsg = async ({
 		);
 
 		const signingExpiredPromise = new Promise<never>((_resolve, reject) => {
-			timeoutId = setTimeout(() => {
+			const expire = () => {
 				onExpired?.();
 				reject(new AuctionSlotExpiredError());
-			}, expirationTimeMs);
+			};
+
+			timeoutId = setTimeout(expire, expirationTimeMs);
+
+			if (slotSource) {
+				intervalId = setInterval(() => {
+					const slot = slotSource();
+					if (slot > 0 && slot >= signingDeadlineSlot) {
+						expire();
+					}
+				}, SIGNING_DEADLINE_POLL_INTERVAL_MS);
+			}
 		});
 
 		// Ensure that the user signs the message before the expiration time
@@ -386,6 +434,9 @@ export const signSwiftOrderMsg = async ({
 	} finally {
 		if (timeoutId) {
 			clearTimeout(timeoutId);
+		}
+		if (intervalId) {
+			clearInterval(intervalId);
 		}
 	}
 };
@@ -411,6 +462,8 @@ interface SendSwiftOrderParams {
 	signingAuthority: PublicKey;
 	/** Number of slots till the end of the auction (optional) */
 	slotsTillAuctionEnd: number;
+	/** Live slot duration, resolved by the caller from `State` */
+	slotDuration: SlotDurationMs;
 	/** Multiplier for the SWIFT confirmation timeout (after sending SWIFT order) */
 	confirmationMultiplier?: number;
 	/** Optionally send a different connection for the confirmation step, possibly for a faster commitment */
@@ -446,6 +499,7 @@ export const sendSwiftOrder = ({
 	takerAuthority,
 	signingAuthority,
 	slotsTillAuctionEnd,
+	slotDuration,
 	confirmationMultiplier,
 	confirmationConnection,
 }: SendSwiftOrderParams): SwiftOrderObservable => {
@@ -464,7 +518,11 @@ export const sendSwiftOrder = ({
 		takerAuthority,
 		signedMsgUserOrdersAccountPubkey,
 		signedMsgOrderUuid,
-		getSwiftConfirmationTimeoutMs(slotsTillAuctionEnd, confirmationMultiplier),
+		getSwiftConfirmationTimeoutMs(
+			slotsTillAuctionEnd,
+			confirmationMultiplier,
+			slotDuration
+		),
 		signingAuthority
 	);
 
@@ -474,35 +532,68 @@ export const sendSwiftOrder = ({
 /**
  * Computes the timing parameters for a SWIFT order:
  * - slotsTillAuctionEnd: how many slots until the auction is considered ended
- * - expirationTimeMs: how long (in ms) the user has to sign before the window expires
+ * - signingDeadlineSlot: the absolute slot the signature must land before
+ * - expirationTimeMs: the same window in ms, a backstop for a dead slot feed
  *
  * For market orders, auction duration + signing buffer is used directly.
  * For non-market orders, a minimum is enforced because limit auctions can have
  * very small durations but the order is still valid after the auction ends.
+ *
+ * The deadline is anchored on the prep `currentSlot`, not on the order's own
+ * slot, because `slotsTillAuctionEnd` already includes the signing buffer.
  */
+/**
+ * The signing window for a prepared order. `signingDeadlineSlot` is the
+ * authoritative bound: `expirationTimeMs` is the same window converted at the
+ * live duration, a backstop for when the slot feed is dead. Consumers showing
+ * a countdown should use these rather than recomputing the window, which would
+ * drift from the guard the moment the formula changes.
+ */
+export type SwiftOrderTiming = {
+	slotsTillAuctionEnd: number;
+	signingDeadlineSlot: number;
+	expirationTimeMs: number;
+};
+
 const computeSwiftOrderTiming = (
 	mainOrderParams: OptionalOrderParams,
-	userSigningSlotBuffer: number
-): { slotsTillAuctionEnd: number; expirationTimeMs: number } => {
+	userSigningSlotBuffer: number,
+	currentSlot: number,
+	slotDuration: SlotDurationMs
+): SwiftOrderTiming => {
 	const isMarketOrder =
 		ENUM_UTILS.match(mainOrderParams.orderType, OrderType.ORACLE) ||
 		ENUM_UTILS.match(mainOrderParams.orderType, OrderType.MARKET);
+	const minimumNonAuctionSlots = msToSlotsCeilNum(
+		MINIMUM_SWIFT_NON_AUCTION_ORDER_SIGNING_BUDGET_MS,
+		slotDuration
+	);
 	const slotsTillAuctionEnd = mainOrderParams.auctionDuration
 		? isMarketOrder
 			? userSigningSlotBuffer + mainOrderParams.auctionDuration
 			: Math.max(
-					MINIMUM_SWIFT_NON_AUCTION_ORDER_SIGNING_EXPIRATION_BUFFER_SLOTS,
+					minimumNonAuctionSlots,
 					userSigningSlotBuffer + mainOrderParams.auctionDuration
 				)
-		: MINIMUM_SWIFT_NON_AUCTION_ORDER_SIGNING_EXPIRATION_BUFFER_SLOTS;
+		: minimumNonAuctionSlots;
 
-	const expirationTimeMs =
+	// The minimum floor can exceed a very short auction, which would put the
+	// deadline at or past the auction end and let the guard pass an order that
+	// can no longer fill. Cap it one slot short of the end so the deadline is
+	// always strictly inside the window. No-op for the durations in use today.
+	const signingWindowSlots = Math.min(
 		Math.max(
 			slotsTillAuctionEnd - SWIFT_ORDER_SIGNING_EXPIRATION_BUFFER_SLOTS,
 			MINIMUM_SWIFT_ORDER_SIGNING_EXPIRATION_BUFFER_SLOTS
-		) * SLOT_TIME_ESTIMATE_MS;
+		),
+		slotsTillAuctionEnd - 1
+	);
 
-	return { slotsTillAuctionEnd, expirationTimeMs };
+	return {
+		slotsTillAuctionEnd,
+		signingDeadlineSlot: currentSlot + signingWindowSlots,
+		expirationTimeMs: slotsToMsNum(signingWindowSlots, slotDuration),
+	};
 };
 
 type PrepSwiftOrderMessageParams = {
@@ -511,6 +602,7 @@ type PrepSwiftOrderMessageParams = {
 	userAccountPubKey: PublicKey;
 	marketIndex: number;
 	userSigningSlotBuffer: number;
+	slotDuration: SlotDurationMs;
 	isDelegate?: boolean;
 	orderParams: {
 		main: OptionalOrderParams;
@@ -538,6 +630,7 @@ export const prepSwiftOrderMessage = async ({
 	userAccountPubKey,
 	marketIndex,
 	userSigningSlotBuffer,
+	slotDuration,
 	isDelegate = false,
 	orderParams,
 	builderParams,
@@ -557,16 +650,20 @@ export const prepSwiftOrderMessage = async ({
 			subAccountId,
 		},
 		currentSlot,
+		slotDuration,
 		isDelegate,
 		orderParams,
 		userSigningSlotBuffer,
 		builderParams,
 	});
 
-	const { slotsTillAuctionEnd, expirationTimeMs } = computeSwiftOrderTiming(
-		orderParams.main,
-		resolvedUserSigningSlotBuffer
-	);
+	const { slotsTillAuctionEnd, signingDeadlineSlot, expirationTimeMs } =
+		computeSwiftOrderTiming(
+			orderParams.main,
+			resolvedUserSigningSlotBuffer,
+			currentSlot,
+			slotDuration
+		);
 
 	return {
 		hexEncodedSwiftOrderMessage,
@@ -575,6 +672,7 @@ export const prepSwiftOrderMessage = async ({
 		signedMsgOrderUuid,
 		marketIndex,
 		slotsTillAuctionEnd,
+		signingDeadlineSlot,
 		expirationTimeMs,
 	};
 };
@@ -585,6 +683,7 @@ type PrepSignAndSendSwiftOrderParams = {
 	userAccountPubKey: PublicKey;
 	marketIndex: number;
 	userSigningSlotBuffer: number;
+	slotDuration: SlotDurationMs;
 	swiftOptions: SwiftOrderOptions;
 	/** Multiplier for the SWIFT confirmation timeout (after sending SWIFT order). Default is 1.
 	 *
@@ -646,6 +745,7 @@ export const prepSignAndSendSwiftOrder = async ({
 	userAccountPubKey,
 	marketIndex,
 	userSigningSlotBuffer,
+	slotDuration,
 	swiftOptions,
 	orderParams,
 	builderParams,
@@ -656,6 +756,7 @@ export const prepSignAndSendSwiftOrder = async ({
 		signedMsgOrderUuid,
 		signedMsgOrderParamsMessage,
 		slotsTillAuctionEnd,
+		signingDeadlineSlot,
 		expirationTimeMs,
 	} = await prepSwiftOrderMessage({
 		velocityClient,
@@ -663,20 +764,24 @@ export const prepSignAndSendSwiftOrder = async ({
 		userAccountPubKey,
 		marketIndex,
 		userSigningSlotBuffer,
+		slotDuration,
 		isDelegate: swiftOptions.isDelegate || false,
 		orderParams,
 		builderParams,
 	});
 
 	swiftOptions.callbacks?.onOrderParamsMessagePrepped?.(
-		signedMsgOrderParamsMessage
+		signedMsgOrderParamsMessage,
+		{ slotsTillAuctionEnd, signingDeadlineSlot, expirationTimeMs }
 	);
 
 	// Ensure that the user signs the message before the expiration time
 	const signedMessage = await signSwiftOrderMsg({
 		wallet: swiftOptions.wallet,
 		hexEncodedSwiftOrderMessage: hexEncodedSwiftOrderMessage.uInt8Array,
+		signingDeadlineSlot,
 		expirationTimeMs,
+		slotSource: swiftOptions.slotSource,
 		onExpired: () =>
 			swiftOptions.callbacks?.onSigningExpiry?.(signedMsgOrderParamsMessage),
 	});
@@ -702,6 +807,7 @@ export const prepSignAndSendSwiftOrder = async ({
 			swiftOptions.wallet.signingAuthority ??
 			swiftOptions.wallet.takerAuthority,
 		slotsTillAuctionEnd,
+		slotDuration,
 		confirmationMultiplier,
 		confirmationConnection: new Connection(
 			velocityClient.connection.rpcEndpoint,

--- a/common-ts/src/drift/base/constants/auction.ts
+++ b/common-ts/src/drift/base/constants/auction.ts
@@ -1,7 +1,7 @@
 import { msToSlotsCeilNum, SlotDurationMs } from '@velocity-exchange/sdk';
 
 /** `Order.auctionDuration` is a u8, so an inflated ramp clamps here. */
-const MAX_AUCTION_DURATION_SLOTS = 255;
+export const MAX_AUCTION_DURATION_SLOTS = 255;
 
 /** Default limit-auction ramp. */
 export const DEFAULT_LIMIT_AUCTION_DURATION_MS = 24_000;

--- a/common-ts/src/drift/base/constants/auction.ts
+++ b/common-ts/src/drift/base/constants/auction.ts
@@ -1,9 +1,43 @@
+import { msToSlotsCeilNum, SlotDurationMs } from '@velocity-exchange/sdk';
+
+/** `Order.auctionDuration` is a u8, so an inflated ramp clamps here. */
+const MAX_AUCTION_DURATION_SLOTS = 255;
+
+/** Default limit-auction ramp. */
+export const DEFAULT_LIMIT_AUCTION_DURATION_MS = 24_000;
+
+/**
+ * Default market/oracle auction ramp used when the caller does not supply one.
+ * Mirrors the DLOB server's default so the network-free fallback tiers (L2,
+ * vAMM) produce a non-null duration. A null/0 duration on a signed-message
+ * order is rejected by the swift server with `InvalidOrderAuction`.
+ */
+export const DEFAULT_MARKET_AUCTION_DURATION_MS = 8_000;
+
+export const getDefaultLimitAuctionDurationSlots = (
+	slotDuration: SlotDurationMs
+): number =>
+	Math.min(
+		msToSlotsCeilNum(DEFAULT_LIMIT_AUCTION_DURATION_MS, slotDuration),
+		MAX_AUCTION_DURATION_SLOTS
+	);
+
+export const getDefaultMarketAuctionDurationSlots = (
+	slotDuration: SlotDurationMs
+): number =>
+	Math.min(
+		msToSlotsCeilNum(DEFAULT_MARKET_AUCTION_DURATION_MS, slotDuration),
+		MAX_AUCTION_DURATION_SLOTS
+	);
+
+/**
+ * @deprecated A slot count fixed at the 400ms baseline. Use
+ * {@link getDefaultLimitAuctionDurationSlots} with the live slot duration.
+ */
 export const DEFAULT_LIMIT_AUCTION_DURATION = 60;
 
 /**
- * Default market/oracle auction duration (in slots) used when the caller does not
- * supply one. Mirrors the DLOB server's default so the network-free fallback tiers
- * (L2, vAMM) produce a non-null duration — a null/0 duration on a signed-message
- * order is rejected by the swift server with `InvalidOrderAuction`.
+ * @deprecated A slot count fixed at the 400ms baseline. Use
+ * {@link getDefaultMarketAuctionDurationSlots} with the live slot duration.
  */
 export const DEFAULT_MARKET_AUCTION_DURATION = 20;

--- a/common-ts/src/drift/cli.ts
+++ b/common-ts/src/drift/cli.ts
@@ -3,6 +3,7 @@ import { PublicKey, VersionedTransaction } from '@solana/web3.js';
 import {
 	BN,
 	currentSlotClock,
+	SLOT_DURATION_FLOOR,
 	loadKeypair,
 	PositionDirection,
 	PostOnlyParams,
@@ -255,6 +256,12 @@ async function initializeCentralServerVelocity(): Promise<void> {
 /**
  * The live slot duration, read from `State` against the current chain slot. The
  * CLI is the outermost caller, so it resolves the value the library receives.
+ *
+ * Everything this CLI feeds the duration to is a user-protection window: order
+ * signing budgets and auction ramps. On a dead feed it therefore assumes the
+ * shortest scheduled slot rather than the baseline, which under-promises the
+ * wall clock instead of doubling it. Baseline is the safe assumption in the
+ * other direction, for staleness ceilings, which nothing here computes.
  */
 async function resolveSlotDuration(): Promise<SlotDurationMs> {
 	const client = centralServerVelocity.velocityClient;
@@ -263,8 +270,9 @@ async function resolveSlotDuration(): Promise<SlotDurationMs> {
 
 	if (!isLive) {
 		console.warn(
-			`⚠️  Live slot duration unavailable, assuming ${slotDurationMs}ms per slot`
+			`⚠️  Live slot duration unavailable, assuming ${SLOT_DURATION_FLOOR}ms per slot`
 		);
+		return SLOT_DURATION_FLOOR;
 	}
 
 	return slotDurationMs;

--- a/common-ts/src/drift/cli.ts
+++ b/common-ts/src/drift/cli.ts
@@ -1,6 +1,7 @@
 import * as anchor from '@coral-xyz/anchor';
 import { PublicKey, VersionedTransaction } from '@solana/web3.js';
 import {
+	activeSlotDurationFromState,
 	BN,
 	loadKeypair,
 	PositionDirection,
@@ -11,6 +12,7 @@ import {
 	PRICE_PRECISION,
 	MainnetSpotMarkets,
 	DevnetSpotMarkets,
+	SlotDurationMs,
 	VelocityEnv,
 } from '@velocity-exchange/sdk';
 import { sign } from 'tweetnacl';
@@ -251,6 +253,16 @@ async function initializeCentralServerVelocity(): Promise<void> {
 }
 
 /**
+ * The live slot duration, read from `State` against the current chain slot. The
+ * CLI is the outermost caller, so it resolves the value the library receives.
+ */
+async function resolveSlotDuration(): Promise<SlotDurationMs> {
+	const client = centralServerVelocity.velocityClient;
+	const slot = await client.connection.getSlot('confirmed');
+	return activeSlotDurationFromState(client.getStateAccount(), new BN(slot));
+}
+
+/**
  * Execute a regular transaction
  */
 async function executeTransaction(
@@ -292,6 +304,7 @@ async function signAndSendSwiftOrderMessage(
 		},
 		hexEncodedSwiftOrderMessage:
 			swiftMessage.hexEncodedSwiftOrderMessage.uInt8Array,
+		signingDeadlineSlot: swiftMessage.signingDeadlineSlot,
 		expirationTimeMs: swiftMessage.expirationTimeMs,
 	});
 
@@ -309,6 +322,7 @@ async function signAndSendSwiftOrderMessage(
 		takerAuthority: wallet.publicKey,
 		signingAuthority: wallet.publicKey,
 		slotsTillAuctionEnd: swiftMessage.slotsTillAuctionEnd,
+		slotDuration: await resolveSlotDuration(),
 	});
 
 	await new Promise<void>((resolve, reject) => {
@@ -663,6 +677,7 @@ async function openPerpMarketOrderCommand(args: CliArgs): Promise<void> {
 		amount: amountBN,
 		useSwift: false,
 		positionMaxLeverage: 10,
+		slotDuration: await resolveSlotDuration(),
 	});
 
 	await executeTransaction(orderTxn as VersionedTransaction, 'Open Perp Order');
@@ -715,6 +730,7 @@ async function openPerpMarketOrderSwiftCommand(args: CliArgs): Promise<void> {
 			amount: amountBN,
 			useSwift: true,
 			positionMaxLeverage: 10,
+			slotDuration: await resolveSlotDuration(),
 		});
 
 		await signAndSendSwiftOrderMessage(
@@ -847,6 +863,7 @@ async function openPerpNonMarketOrderCommand(args: CliArgs): Promise<void> {
 		assetType: assetType as 'base' | 'quote',
 		amount: amountBN,
 		positionMaxLeverage: 10,
+		slotDuration: await resolveSlotDuration(),
 	});
 
 	await executeTransaction(
@@ -947,6 +964,7 @@ async function openPerpNonMarketOrderSwiftCommand(
 				amount: amountBN,
 				useSwift: true,
 				positionMaxLeverage: 10,
+				slotDuration: await resolveSlotDuration(),
 			});
 
 		await signAndSendSwiftOrderMessage(
@@ -1179,7 +1197,8 @@ async function editOrderCommand(args: CliArgs): Promise<void> {
 	const editOrderTxn = await centralServerVelocity.getEditOrderTxn(
 		userAccountPubkey,
 		orderId,
-		editParams
+		editParams,
+		await resolveSlotDuration()
 	);
 
 	await executeTransaction(editOrderTxn as VersionedTransaction, 'Edit Order');

--- a/common-ts/src/drift/cli.ts
+++ b/common-ts/src/drift/cli.ts
@@ -1,8 +1,8 @@
 import * as anchor from '@coral-xyz/anchor';
 import { PublicKey, VersionedTransaction } from '@solana/web3.js';
 import {
-	activeSlotDurationFromState,
 	BN,
+	currentSlotClock,
 	loadKeypair,
 	PositionDirection,
 	PostOnlyParams,
@@ -259,7 +259,15 @@ async function initializeCentralServerVelocity(): Promise<void> {
 async function resolveSlotDuration(): Promise<SlotDurationMs> {
 	const client = centralServerVelocity.velocityClient;
 	const slot = await client.connection.getSlot('confirmed');
-	return activeSlotDurationFromState(client.getStateAccount(), new BN(slot));
+	const { slotDurationMs, isLive } = currentSlotClock(client, slot);
+
+	if (!isLive) {
+		console.warn(
+			`⚠️  Live slot duration unavailable, assuming ${slotDurationMs}ms per slot`
+		);
+	}
+
+	return slotDurationMs;
 }
 
 /**

--- a/common-ts/src/utils/orders/flags.ts
+++ b/common-ts/src/utils/orders/flags.ts
@@ -8,12 +8,10 @@ import {
 	PERCENTAGE_PRECISION,
 	SlotDurationMs,
 } from '@velocity-exchange/sdk';
+import { MAX_AUCTION_DURATION_SLOTS } from '../../drift/base/constants/auction';
 
 const MIN_AUCTION_DURATION_STEPS = new BN(1);
 const MAX_AUCTION_DURATION_STEPS = new BN(180);
-
-/** `Order.auctionDuration` is a u8, so an inflated ramp clamps here. */
-const MAX_AUCTION_DURATION_SLOTS = 255;
 
 /**
  * Mirrors the program's `get_auction_duration`. The ramp is granted in steps of

--- a/common-ts/src/utils/orders/flags.ts
+++ b/common-ts/src/utils/orders/flags.ts
@@ -2,25 +2,52 @@ import {
 	BN,
 	ContractTier,
 	isOneOfVariant,
+	MILLIS_UNIT,
+	Millis,
+	millisToSlotsCeil,
 	PERCENTAGE_PRECISION,
+	SlotDurationMs,
 } from '@velocity-exchange/sdk';
 
+const MIN_AUCTION_DURATION_STEPS = new BN(1);
+const MAX_AUCTION_DURATION_STEPS = new BN(180);
+
+/** `Order.auctionDuration` is a u8, so an inflated ramp clamps here. */
+const MAX_AUCTION_DURATION_SLOTS = 255;
+
+/**
+ * Mirrors the program's `get_auction_duration`. The ramp is granted in steps of
+ * `MILLIS_UNIT` (the historical 400ms calibration of the per-1% rate), then
+ * expressed in actual slots at the live duration so the wall-clock ramp is the
+ * same at every slot-time gate.
+ */
 export function getPerpAuctionDuration(
 	priceDiff: BN,
 	price: BN,
-	contractTier: ContractTier
+	contractTier: ContractTier,
+	slotDuration: SlotDurationMs
 ): number {
 	const percentDiff = priceDiff.mul(PERCENTAGE_PRECISION).div(price);
 
-	const slotsPerBp = isOneOfVariant(contractTier, ['a', 'b'])
+	const stepsPerPercent = isOneOfVariant(contractTier, ['a', 'b'])
 		? new BN(100)
 		: new BN(60);
 
-	const rawSlots = percentDiff
-		.mul(slotsPerBp)
-		.div(PERCENTAGE_PRECISION.divn(100));
+	const perPercent = PERCENTAGE_PRECISION.divn(100);
+	const rawSteps = percentDiff
+		.mul(stepsPerPercent)
+		.add(perPercent.subn(1))
+		.div(perPercent);
 
-	const clamped = BN.min(BN.max(rawSlots, new BN(5)), new BN(180));
+	const steps = BN.min(
+		BN.max(rawSteps, MIN_AUCTION_DURATION_STEPS),
+		MAX_AUCTION_DURATION_STEPS
+	);
 
-	return clamped.toNumber();
+	const duration = MILLIS_UNIT.mul(steps) as Millis;
+
+	return Math.min(
+		millisToSlotsCeil(duration, slotDuration).toNumber(),
+		MAX_AUCTION_DURATION_SLOTS
+	);
 }

--- a/common-ts/src/utils/positions/open.ts
+++ b/common-ts/src/utils/positions/open.ts
@@ -19,6 +19,7 @@ import {
 	calculateUnsettledFundingPnl,
 	isOracleValid,
 	AMM_RESERVE_PRECISION,
+	SlotDurationMs,
 } from '@velocity-exchange/sdk';
 import { OpenPosition } from '../../types';
 import { calculatePotentialProfit } from '../trading/pnl';
@@ -28,6 +29,7 @@ const getOpenPositionData = (
 	userPositions: PerpPosition[],
 	user: User,
 	perpMarketLookup: PerpMarketConfig[],
+	slotDuration: SlotDurationMs,
 	markPriceCallback?: (marketIndex: number) => BN
 ): OpenPosition[] => {
 	const oracleGuardRails = velocityClient.getStateAccount().oracleGuardRails;
@@ -171,7 +173,8 @@ const getOpenPositionData = (
 					perpMarket,
 					oraclePriceData,
 					oracleGuardRails,
-					perpMarket.amm.lastUpdateSlot?.toNumber()
+					perpMarket.amm.lastUpdateSlot?.toNumber(),
+					slotDuration
 				),
 				maxMarginRatio: position.maxMarginRatio,
 			};

--- a/common-ts/src/utils/signedMsgs.ts
+++ b/common-ts/src/utils/signedMsgs.ts
@@ -1,9 +1,18 @@
-import { SLOT_TIME_ESTIMATE_MS } from '@velocity-exchange/sdk';
+import { SlotDurationMs, slotsToMsNum } from '@velocity-exchange/sdk';
+
+/**
+ * Allowance on top of the auction window for the send + websocket confirmation
+ * round trip. A wall-clock network budget, not a slot count.
+ */
+export const SWIFT_CONFIRMATION_ROUND_TRIP_MS = 6_000;
 
 export function getSwiftConfirmationTimeoutMs(
 	slotsTillAuctionEnd: number,
-	multiplier?: number
+	multiplier: number | undefined,
+	slotDuration: SlotDurationMs
 ): number {
-	const baseMs = ((slotsTillAuctionEnd ?? 0) + 15) * SLOT_TIME_ESTIMATE_MS;
+	const baseMs =
+		slotsToMsNum(slotsTillAuctionEnd, slotDuration) +
+		SWIFT_CONFIRMATION_ROUND_TRIP_MS;
 	return baseMs * (multiplier ?? 1);
 }

--- a/common-ts/tests/orderParams/fetchAuctionOrderParams.test.ts
+++ b/common-ts/tests/orderParams/fetchAuctionOrderParams.test.ts
@@ -4,6 +4,7 @@ import {
 	OrderType,
 	PositionDirection,
 	PRICE_PRECISION,
+	SLOT_DURATION_BASELINE,
 	User,
 	VelocityClient,
 } from '@velocity-exchange/sdk';
@@ -17,7 +18,7 @@ import {
 } from '../../src/drift/base/actions/trade/openPerpOrder/dlobServer';
 import { ENUM_UTILS } from '../../src';
 import { mockPerpMarket } from './fixtures/mockPerpMarket';
-import { DEFAULT_MARKET_AUCTION_DURATION } from '../../src/drift/base/constants/auction';
+import { getDefaultMarketAuctionDurationSlots } from '../../src/drift/base/constants/auction';
 
 const DLOB_SERVER_HTTP_URL = 'https://test-dlob.example.com';
 
@@ -113,6 +114,7 @@ const baseParams = {
 	amount: new BN(1_000_000_000),
 	dlobServerHttpUrl: DLOB_SERVER_HTTP_URL,
 	reduceOnly: false,
+	slotDuration: SLOT_DURATION_BASELINE,
 };
 
 const expectRejection = async (
@@ -486,7 +488,7 @@ describe('fetchAuctionOrderParams', () => {
 			).to.be.true;
 		});
 
-		it('defaults auctionDuration to DEFAULT_MARKET_AUCTION_DURATION when the caller omits it', async () => {
+		it('defaults auctionDuration to the default market auction duration when the caller omits it', async () => {
 			// The UI sends auctionDuration=undefined, relying on the DLOB server to
 			// fill it in. The network-free fallback must resolve a non-null duration
 			// itself, otherwise the swift server rejects the signed order with
@@ -498,7 +500,7 @@ describe('fetchAuctionOrderParams', () => {
 			});
 
 			expect(result.orderParams.auctionDuration).to.equal(
-				DEFAULT_MARKET_AUCTION_DURATION
+				getDefaultMarketAuctionDurationSlots(SLOT_DURATION_BASELINE)
 			);
 		});
 

--- a/common-ts/tests/orderParams/fixtures/rawMockPerpMarkets.ts
+++ b/common-ts/tests/orderParams/fixtures/rawMockPerpMarkets.ts
@@ -59,6 +59,8 @@ export const mockAMM: AMM = {
 	feePool: {
 		scaledBalance: new BN(0),
 		marketIndex: 0,
+		pendingInterestSplitDust: 0,
+		pendingInterestDust: new BN(0),
 	},
 	concentrationCoef: new BN(0),
 	minBaseAssetReserve: BASE_RESERVE.muln(9).divn(10),
@@ -146,10 +148,14 @@ function mockPerpMarketCommon(): Omit<
 		pnlPool: {
 			scaledBalance: new BN(0),
 			marketIndex: 0,
+			pendingInterestSplitDust: 0,
+			pendingInterestDust: new BN(0),
 		},
 		protocolFeePool: {
 			scaledBalance: new BN(0),
 			marketIndex: 0,
+			pendingInterestSplitDust: 0,
+			pendingInterestDust: new BN(0),
 		},
 		feeLedger: {
 			totalExchangeFee: new BN(0),
@@ -214,7 +220,9 @@ function mockPerpMarketCommon(): Omit<
 		orderStepSize: new BN(1),
 		orderTickSize: new BN(1),
 		pendingRevenueShare: new BN(0),
+		takerFeeAddonTenthBps: 0,
 		bankruptcyIfFloorPct: 0,
+		pendingBankruptcyClaims: 0,
 	};
 }
 

--- a/common-ts/tests/utils/idleWaitTime.test.ts
+++ b/common-ts/tests/utils/idleWaitTime.test.ts
@@ -89,6 +89,26 @@ describe('getIdleWaitTimeMinutes', () => {
 		});
 	});
 
+	it('nets liabilities off assets when reading the equity cut', () => {
+		// $1200 of assets against $300 of borrows is $900 of equity, under the
+		// cut, so the accelerated hour applies despite the gross asset value.
+		const user = {
+			getUserAccountOrThrow: () => ({ lastActiveSlot: new BN(1_000_000) }),
+			getSpotMarketAssetAndLiabilityValue: () => ({
+				totalAssetValue: QUOTE_PRECISION.muln(1200),
+				totalLiabilityValue: QUOTE_PRECISION.muln(300),
+			}),
+		} as unknown as User;
+
+		expect(
+			ACCOUNT_DELETION_HELPERS.getIdleWaitTimeMinutes(
+				user,
+				1_000_000,
+				400 as SlotDurationMs
+			)
+		).to.equal(60);
+	});
+
 	it('uses the week-long window at or above the $1000 equity cut', () => {
 		// `validate_user_is_idle` only grants the accelerated hour below $1000 of
 		// equity. Reading the hour unconditionally under-states a funded

--- a/common-ts/tests/utils/idleWaitTime.test.ts
+++ b/common-ts/tests/utils/idleWaitTime.test.ts
@@ -1,0 +1,72 @@
+import { BN, IDLE_TIME, SlotDurationMs, User } from '@velocity-exchange/sdk';
+import { expect } from 'chai';
+import { ACCOUNT_DELETION_HELPERS } from '../../src/actions/actionHelpers/accountDeletionHelpers';
+
+const GATES = [400, 350, 300, 250, 200] as SlotDurationMs[];
+
+const IDLE_TIME_MS = IDLE_TIME.toNumber();
+
+const userLastActiveAt = (lastActiveSlot: number) =>
+	({
+		getUserAccountOrThrow: () => ({ lastActiveSlot: new BN(lastActiveSlot) }),
+	}) as unknown as User;
+
+const waitMinutes = (
+	elapsedSlots: number,
+	slotDuration: SlotDurationMs,
+	currentSlot = 1_000_000
+) =>
+	ACCOUNT_DELETION_HELPERS.getIdleWaitTimeMinutes(
+		userLastActiveAt(currentSlot - elapsedSlots),
+		currentSlot,
+		slotDuration
+	);
+
+describe('getIdleWaitTimeMinutes', () => {
+	it('reproduces the legacy estimate at the 400ms baseline', () => {
+		// 9000 slots was the pre-gate encoding of the one-hour idle window.
+		expect(waitMinutes(0, 400 as SlotDurationMs)).to.equal(60);
+		expect(waitMinutes(4500, 400 as SlotDurationMs)).to.equal(30);
+		expect(waitMinutes(9000, 400 as SlotDurationMs)).to.equal(0);
+	});
+
+	it('reports the same wait for the same wall-clock inactivity at every gate', () => {
+		// multiples of 42_000ms divide evenly into every gate's slot duration
+		[0, 588_000, 1_512_000, 2_940_000].forEach((elapsedMs) => {
+			const expected = Math.ceil((IDLE_TIME_MS - elapsedMs) / 60_000);
+			GATES.forEach((slotDuration) => {
+				expect(waitMinutes(elapsedMs / slotDuration, slotDuration)).to.equal(
+					expected
+				);
+			});
+		});
+	});
+
+	it('never under-states the remaining wall-clock wait', () => {
+		GATES.forEach((slotDuration) => {
+			for (let elapsedSlots = 0; elapsedSlots < 20_000; elapsedSlots += 137) {
+				const remainingMs = Math.max(
+					IDLE_TIME_MS - elapsedSlots * slotDuration,
+					0
+				);
+				expect(waitMinutes(elapsedSlots, slotDuration) * 60_000).to.be.at.least(
+					remainingMs
+				);
+			}
+		});
+	});
+
+	it('clamps to zero once the window has elapsed', () => {
+		GATES.forEach((slotDuration) => {
+			expect(waitMinutes(1_000_000, slotDuration)).to.equal(0);
+		});
+	});
+
+	it('treats a last-active slot ahead of the current slot as no elapsed time', () => {
+		GATES.forEach((slotDuration) => {
+			expect(waitMinutes(-500, slotDuration)).to.equal(
+				Math.ceil(IDLE_TIME_MS / 60_000)
+			);
+		});
+	});
+});

--- a/common-ts/tests/utils/idleWaitTime.test.ts
+++ b/common-ts/tests/utils/idleWaitTime.test.ts
@@ -1,23 +1,42 @@
-import { BN, IDLE_TIME, SlotDurationMs, User } from '@velocity-exchange/sdk';
+import {
+	BN,
+	IDLE_TIME,
+	QUOTE_PRECISION,
+	SlotDurationMs,
+	User,
+	ZERO,
+} from '@velocity-exchange/sdk';
 import { expect } from 'chai';
 import { ACCOUNT_DELETION_HELPERS } from '../../src/actions/actionHelpers/accountDeletionHelpers';
 
 const GATES = [400, 350, 300, 250, 200] as SlotDurationMs[];
 
 const IDLE_TIME_MS = IDLE_TIME.toNumber();
+const WEEK_MS = 604_800_000;
 
-const userLastActiveAt = (lastActiveSlot: number) =>
+/** Below the program's $1000 equity cut, where the one-hour window applies. */
+const ACCELERATED_EQUITY = QUOTE_PRECISION.muln(999);
+
+const userLastActiveAt = (
+	lastActiveSlot: number,
+	equity = ACCELERATED_EQUITY
+) =>
 	({
 		getUserAccountOrThrow: () => ({ lastActiveSlot: new BN(lastActiveSlot) }),
+		getSpotMarketAssetAndLiabilityValue: () => ({
+			totalAssetValue: equity,
+			totalLiabilityValue: ZERO,
+		}),
 	}) as unknown as User;
 
 const waitMinutes = (
 	elapsedSlots: number,
 	slotDuration: SlotDurationMs,
-	currentSlot = 1_000_000
+	currentSlot = 1_000_000,
+	equity = ACCELERATED_EQUITY
 ) =>
 	ACCOUNT_DELETION_HELPERS.getIdleWaitTimeMinutes(
-		userLastActiveAt(currentSlot - elapsedSlots),
+		userLastActiveAt(currentSlot - elapsedSlots, equity),
 		currentSlot,
 		slotDuration
 	);
@@ -67,6 +86,35 @@ describe('getIdleWaitTimeMinutes', () => {
 			expect(waitMinutes(-500, slotDuration)).to.equal(
 				Math.ceil(IDLE_TIME_MS / 60_000)
 			);
+		});
+	});
+
+	it('uses the week-long window at or above the $1000 equity cut', () => {
+		// `validate_user_is_idle` only grants the accelerated hour below $1000 of
+		// equity. Reading the hour unconditionally under-states a funded
+		// account's wait by a week.
+		const funded = QUOTE_PRECISION.muln(1000);
+
+		GATES.forEach((slotDuration) => {
+			expect(waitMinutes(0, slotDuration, 1_000_000, funded)).to.equal(
+				Math.ceil(WEEK_MS / 60_000)
+			);
+
+			const halfway = WEEK_MS / 2 / slotDuration;
+			expect(waitMinutes(halfway, slotDuration, 1_000_000, funded)).to.equal(
+				Math.ceil(WEEK_MS / 2 / 60_000)
+			);
+
+			// The hour-long window has long since elapsed, but the account is not
+			// idle-able yet.
+			expect(
+				waitMinutes(
+					IDLE_TIME_MS / slotDuration,
+					slotDuration,
+					1_000_000,
+					funded
+				)
+			).to.be.greaterThan(0);
 		});
 	});
 });

--- a/common-ts/tests/utils/perpAuctionDuration.test.ts
+++ b/common-ts/tests/utils/perpAuctionDuration.test.ts
@@ -1,0 +1,165 @@
+import {
+	BN,
+	ContractTier,
+	PRICE_PRECISION,
+	SLOT_DURATION_BASELINE,
+	SlotDurationMs,
+} from '@velocity-exchange/sdk';
+import { expect } from 'chai';
+import { getPerpAuctionDuration } from '../../src/utils/orders/flags';
+import {
+	DEFAULT_LIMIT_AUCTION_DURATION,
+	DEFAULT_LIMIT_AUCTION_DURATION_MS,
+	DEFAULT_MARKET_AUCTION_DURATION,
+	DEFAULT_MARKET_AUCTION_DURATION_MS,
+	getDefaultLimitAuctionDurationSlots,
+	getDefaultMarketAuctionDurationSlots,
+} from '../../src/drift/base/constants/auction';
+
+const GATES = [400, 350, 300, 250, 200] as SlotDurationMs[];
+
+const PRICE = new BN(100).mul(PRICE_PRECISION);
+
+const duration = (priceDiff: BN, slotDuration: SlotDurationMs) =>
+	getPerpAuctionDuration(priceDiff, PRICE, ContractTier.C, slotDuration);
+
+describe('getPerpAuctionDuration', () => {
+	// Values pinned by the program's own suite in
+	// programs/velocity/src/state/order_params/tests.rs.
+	describe('matches the program at the 400ms baseline', () => {
+		const cases: [BN, number][] = [
+			[new BN(0), 1],
+			[PRICE_PRECISION.divn(10), 6],
+			[PRICE_PRECISION.divn(2), 30],
+			[PRICE_PRECISION, 60],
+			[PRICE_PRECISION.muln(2), 120],
+			[PRICE_PRECISION.muln(3), 180],
+		];
+
+		cases.forEach(([priceDiff, expected]) => {
+			it(`grants ${expected} slots for a price diff of ${priceDiff.toString()}`, () => {
+				expect(duration(priceDiff, SLOT_DURATION_BASELINE)).to.equal(expected);
+			});
+		});
+	});
+
+	it('grants 100 steps per percent for the safest tiers', () => {
+		expect(
+			getPerpAuctionDuration(
+				PRICE_PRECISION,
+				PRICE,
+				ContractTier.A,
+				SLOT_DURATION_BASELINE
+			)
+		).to.equal(100);
+		expect(
+			getPerpAuctionDuration(
+				PRICE_PRECISION,
+				PRICE,
+				ContractTier.B,
+				SLOT_DURATION_BASELINE
+			)
+		).to.equal(100);
+	});
+
+	// A 2% diff at tier C is 120 steps x 400ms = 48s.
+	describe('scales the slot count so the wall-clock ramp is constant', () => {
+		const expectedByGate: [SlotDurationMs, number][] = [
+			[400 as SlotDurationMs, 120],
+			[350 as SlotDurationMs, 138],
+			[300 as SlotDurationMs, 160],
+			[250 as SlotDurationMs, 192],
+			[200 as SlotDurationMs, 240],
+		];
+
+		expectedByGate.forEach(([slotDuration, expected]) => {
+			it(`grants ${expected} slots at ${slotDuration}ms`, () => {
+				const slots = duration(PRICE_PRECISION.muln(2), slotDuration);
+				expect(slots).to.equal(expected);
+				expect(slots * slotDuration).to.be.at.least(48_000);
+				expect(slots * slotDuration).to.be.below(48_000 + slotDuration);
+			});
+		});
+	});
+
+	// The 180-step (72s) maximum inflates past the u8 ceiling at the fastest gates.
+	describe('clamps at the u8 auctionDuration ceiling', () => {
+		it('is unclamped at 400ms and 350ms', () => {
+			expect(duration(PRICE_PRECISION.muln(3), 400 as SlotDurationMs)).to.equal(
+				180
+			);
+			expect(duration(PRICE_PRECISION.muln(3), 350 as SlotDurationMs)).to.equal(
+				206
+			);
+		});
+
+		it('clamps to 255 at 250ms and 200ms', () => {
+			expect(duration(PRICE_PRECISION.muln(3), 250 as SlotDurationMs)).to.equal(
+				255
+			);
+			expect(duration(PRICE_PRECISION.muln(3), 200 as SlotDurationMs)).to.equal(
+				255
+			);
+		});
+
+		it('never exceeds 255 at any gate for any price diff', () => {
+			GATES.forEach((slotDuration) => {
+				[0, 1, 5, 10, 100].forEach((multiple) => {
+					expect(
+						duration(PRICE_PRECISION.muln(multiple), slotDuration)
+					).to.be.at.most(255);
+				});
+			});
+		});
+	});
+
+	it('grants the one-step minimum as a wall-clock floor', () => {
+		GATES.forEach((slotDuration) => {
+			const slots = duration(new BN(0), slotDuration);
+			expect(slots).to.be.at.least(1);
+			expect(slots * slotDuration).to.be.at.least(400);
+		});
+	});
+});
+
+describe('default auction durations', () => {
+	it('reproduces the legacy slot counts at the 400ms baseline', () => {
+		expect(
+			getDefaultLimitAuctionDurationSlots(SLOT_DURATION_BASELINE)
+		).to.equal(DEFAULT_LIMIT_AUCTION_DURATION);
+		expect(
+			getDefaultMarketAuctionDurationSlots(SLOT_DURATION_BASELINE)
+		).to.equal(DEFAULT_MARKET_AUCTION_DURATION);
+	});
+
+	it('holds its wall-clock length at every gate', () => {
+		GATES.forEach((slotDuration) => {
+			const limit = getDefaultLimitAuctionDurationSlots(slotDuration);
+			expect(limit * slotDuration).to.be.at.least(
+				DEFAULT_LIMIT_AUCTION_DURATION_MS
+			);
+			expect(limit * slotDuration).to.be.below(
+				DEFAULT_LIMIT_AUCTION_DURATION_MS + slotDuration
+			);
+
+			const market = getDefaultMarketAuctionDurationSlots(slotDuration);
+			expect(market * slotDuration).to.be.at.least(
+				DEFAULT_MARKET_AUCTION_DURATION_MS
+			);
+			expect(market * slotDuration).to.be.below(
+				DEFAULT_MARKET_AUCTION_DURATION_MS + slotDuration
+			);
+		});
+	});
+
+	it('never exceeds the u8 auctionDuration ceiling', () => {
+		GATES.forEach((slotDuration) => {
+			expect(getDefaultLimitAuctionDurationSlots(slotDuration)).to.be.at.most(
+				255
+			);
+			expect(getDefaultMarketAuctionDurationSlots(slotDuration)).to.be.at.most(
+				255
+			);
+		});
+	});
+});

--- a/common-ts/tests/utils/swiftOrderTiming.test.ts
+++ b/common-ts/tests/utils/swiftOrderTiming.test.ts
@@ -1,0 +1,193 @@
+import {
+	BASE_PRECISION,
+	getLimitOrderParams,
+	getMarketOrderParams,
+	MarketType,
+	OptionalOrderParams,
+	PositionDirection,
+	PRICE_PRECISION,
+	PublicKey,
+	SlotDurationMs,
+	VelocityClient,
+} from '@velocity-exchange/sdk';
+import { expect } from 'chai';
+import {
+	MINIMUM_SWIFT_NON_AUCTION_ORDER_SIGNING_BUDGET_MS,
+	prepSwiftOrderMessage,
+	USER_SIGNING_MESSAGE_BUFFER_MS,
+} from '../../src/drift/base/actions/trade/openPerpOrder/openSwiftOrder';
+import {
+	getSwiftConfirmationTimeoutMs,
+	SWIFT_CONFIRMATION_ROUND_TRIP_MS,
+} from '../../src/utils/signedMsgs';
+import { getDefaultMarketAuctionDurationSlots } from '../../src/drift/base/constants/auction';
+
+const GATES = [400, 350, 300, 250, 200] as SlotDurationMs[];
+
+const CURRENT_SLOT = 1_000_000;
+
+const clientStub = () =>
+	({
+		connection: {
+			getSlot: async () => CURRENT_SLOT,
+		},
+		encodeSignedMsgOrderParamsMessage: () => Buffer.from([1, 2, 3]),
+	}) as unknown as VelocityClient;
+
+const marketOrder = (auctionDuration: number): OptionalOrderParams =>
+	getMarketOrderParams({
+		marketIndex: 0,
+		marketType: MarketType.PERP,
+		direction: PositionDirection.LONG,
+		baseAssetAmount: BASE_PRECISION,
+		auctionDuration,
+	});
+
+const restingLimitOrder = (): OptionalOrderParams =>
+	getLimitOrderParams({
+		marketIndex: 0,
+		marketType: MarketType.PERP,
+		direction: PositionDirection.LONG,
+		baseAssetAmount: BASE_PRECISION,
+		price: PRICE_PRECISION,
+	});
+
+const timing = (main: OptionalOrderParams, slotDuration: SlotDurationMs) =>
+	prepSwiftOrderMessage({
+		velocityClient: clientStub(),
+		subAccountId: 0,
+		userAccountPubKey: PublicKey.default,
+		marketIndex: 0,
+		userSigningSlotBuffer: 0,
+		slotDuration,
+		orderParams: { main },
+	});
+
+describe('swift order timing', () => {
+	it('reproduces the legacy windows at the 400ms baseline', async () => {
+		const auction = await timing(marketOrder(20), 400 as SlotDurationMs);
+		// 7 signing-buffer slots + 20 auction slots, less the 5-slot guard buffer.
+		expect(auction.slotsTillAuctionEnd).to.equal(27);
+		expect(auction.signingDeadlineSlot).to.equal(CURRENT_SLOT + 22);
+		expect(auction.expirationTimeMs).to.equal(8_800);
+
+		const nonAuction = await timing(restingLimitOrder(), 400 as SlotDurationMs);
+		expect(nonAuction.slotsTillAuctionEnd).to.equal(35);
+		expect(nonAuction.signingDeadlineSlot).to.equal(CURRENT_SLOT + 30);
+		expect(nonAuction.expirationTimeMs).to.equal(12_000);
+	});
+
+	it('keeps the signing deadline inside the auction window at every gate', async () => {
+		for (const slotDuration of GATES) {
+			const mains = [
+				marketOrder(getDefaultMarketAuctionDurationSlots(slotDuration)),
+				marketOrder(1),
+				restingLimitOrder(),
+			];
+
+			for (const main of mains) {
+				const { slotsTillAuctionEnd, signingDeadlineSlot } = await timing(
+					main,
+					slotDuration
+				);
+				expect(signingDeadlineSlot).to.be.below(
+					CURRENT_SLOT + slotsTillAuctionEnd
+				);
+			}
+		}
+	});
+
+	it('keeps the deadline inside the window when a caller passes its own tiny buffer', async () => {
+		// The minimum floor is 5 slots, so without a cap it outruns any window
+		// shorter than that and the guard lets through an order that can no
+		// longer fill. Only reachable when a caller supplies the buffer itself.
+		for (const slotDuration of GATES) {
+			const { slotsTillAuctionEnd, signingDeadlineSlot } =
+				await prepSwiftOrderMessage({
+					velocityClient: clientStub(),
+					subAccountId: 0,
+					userAccountPubKey: PublicKey.default,
+					marketIndex: 0,
+					userSigningSlotBuffer: 1,
+					slotDuration,
+					orderParams: { main: marketOrder(1) },
+				});
+
+			expect(slotsTillAuctionEnd).to.equal(2);
+			expect(signingDeadlineSlot).to.be.below(
+				CURRENT_SLOT + slotsTillAuctionEnd
+			);
+		}
+	});
+
+	it('holds the signing buffer wall-clock constant at every gate', async () => {
+		for (const slotDuration of GATES) {
+			const auctionSlots = getDefaultMarketAuctionDurationSlots(slotDuration);
+			const { slotsTillAuctionEnd } = await timing(
+				marketOrder(auctionSlots),
+				slotDuration
+			);
+
+			const bufferMs = (slotsTillAuctionEnd - auctionSlots) * slotDuration;
+			expect(bufferMs).to.be.at.least(USER_SIGNING_MESSAGE_BUFFER_MS);
+			expect(bufferMs).to.be.below(
+				USER_SIGNING_MESSAGE_BUFFER_MS + slotDuration
+			);
+		}
+	});
+
+	it('holds the non-auction approval budget wall-clock constant at every gate', async () => {
+		for (const slotDuration of GATES) {
+			const { slotsTillAuctionEnd } = await timing(
+				restingLimitOrder(),
+				slotDuration
+			);
+
+			const budgetMs = slotsTillAuctionEnd * slotDuration;
+			expect(budgetMs).to.be.at.least(
+				MINIMUM_SWIFT_NON_AUCTION_ORDER_SIGNING_BUDGET_MS
+			);
+			expect(budgetMs).to.be.below(
+				MINIMUM_SWIFT_NON_AUCTION_ORDER_SIGNING_BUDGET_MS + slotDuration
+			);
+		}
+	});
+
+	it('expresses the signing window in ms at the live duration', async () => {
+		for (const slotDuration of GATES) {
+			const { signingDeadlineSlot, expirationTimeMs } = await timing(
+				marketOrder(getDefaultMarketAuctionDurationSlots(slotDuration)),
+				slotDuration
+			);
+			expect(expirationTimeMs).to.equal(
+				(signingDeadlineSlot - CURRENT_SLOT) * slotDuration
+			);
+		}
+	});
+});
+
+describe('getSwiftConfirmationTimeoutMs', () => {
+	it('reproduces the legacy timeout at the 400ms baseline', () => {
+		expect(
+			getSwiftConfirmationTimeoutMs(27, undefined, 400 as SlotDurationMs)
+		).to.equal((27 + 15) * 400);
+	});
+
+	it('holds its wall-clock length at every gate', () => {
+		GATES.forEach((slotDuration) => {
+			const auctionSlots = Math.ceil(20_000 / slotDuration);
+			expect(
+				getSwiftConfirmationTimeoutMs(auctionSlots, undefined, slotDuration)
+			).to.be.at.least(20_000 + SWIFT_CONFIRMATION_ROUND_TRIP_MS);
+			expect(
+				getSwiftConfirmationTimeoutMs(auctionSlots, undefined, slotDuration)
+			).to.be.below(20_000 + SWIFT_CONFIRMATION_ROUND_TRIP_MS + slotDuration);
+		});
+	});
+
+	it('applies the multiplier to the whole budget', () => {
+		expect(
+			getSwiftConfirmationTimeoutMs(10, 2, 200 as SlotDurationMs)
+		).to.equal((10 * 200 + SWIFT_CONFIRMATION_ROUND_TRIP_MS) * 2);
+	});
+});

--- a/common-ts/tests/utils/swiftOrderTiming.test.ts
+++ b/common-ts/tests/utils/swiftOrderTiming.test.ts
@@ -52,6 +52,35 @@ const restingLimitOrder = (): OptionalOrderParams =>
 		price: PRICE_PRECISION,
 	});
 
+const limitAuctionOrder = (auctionDuration: number): OptionalOrderParams =>
+	getLimitOrderParams({
+		marketIndex: 0,
+		marketType: MarketType.PERP,
+		direction: PositionDirection.LONG,
+		baseAssetAmount: BASE_PRECISION,
+		price: PRICE_PRECISION,
+		auctionDuration,
+		auctionStartPrice: PRICE_PRECISION,
+		auctionEndPrice: PRICE_PRECISION.muln(101).divn(100),
+	});
+
+/**
+ * The slot past which the program stops placing the order, as an offset from the
+ * prep slot: `order_slot + auction_duration`, where `order_slot` is the auction
+ * start. Derived from the program's rule and the published buffer constants, not
+ * from the timing helper's own intermediates, so the assertion is independent.
+ */
+const onChainMaxSlotOffset = (
+	auctionDuration: number,
+	slotDuration: SlotDurationMs
+) => {
+	const budgetMs = auctionDuration
+		? USER_SIGNING_MESSAGE_BUFFER_MS
+		: MINIMUM_SWIFT_NON_AUCTION_ORDER_SIGNING_BUDGET_MS;
+
+	return Math.ceil(budgetMs / slotDuration) + auctionDuration;
+};
+
 const timing = (main: OptionalOrderParams, slotDuration: SlotDurationMs) =>
 	prepSwiftOrderMessage({
 		velocityClient: clientStub(),
@@ -77,21 +106,32 @@ describe('swift order timing', () => {
 		expect(nonAuction.expirationTimeMs).to.equal(12_000);
 	});
 
-	it('keeps the signing deadline inside the auction window at every gate', async () => {
+	it('keeps the signing deadline inside the placement window at every gate', async () => {
 		for (const slotDuration of GATES) {
-			const mains = [
-				marketOrder(getDefaultMarketAuctionDurationSlots(slotDuration)),
-				marketOrder(1),
-				restingLimitOrder(),
+			const cases: [OptionalOrderParams, number][] = [
+				[
+					marketOrder(getDefaultMarketAuctionDurationSlots(slotDuration)),
+					getDefaultMarketAuctionDurationSlots(slotDuration),
+				],
+				[marketOrder(1), 1],
+				[restingLimitOrder(), 0],
+				// A near-touch limit order: the confirmation floor runs well past
+				// the auction, so a deadline clamped against that floor instead of
+				// the chain's bound would let the user sign an order the program
+				// will silently decline to place.
+				[limitAuctionOrder(1), 1],
+				[limitAuctionOrder(5), 5],
+				[limitAuctionOrder(20), 20],
 			];
 
-			for (const main of mains) {
-				const { slotsTillAuctionEnd, signingDeadlineSlot } = await timing(
-					main,
-					slotDuration
-				);
-				expect(signingDeadlineSlot).to.be.below(
-					CURRENT_SLOT + slotsTillAuctionEnd
+			for (const [main, auctionDuration] of cases) {
+				const { signingDeadlineSlot } = await timing(main, slotDuration);
+
+				expect(
+					signingDeadlineSlot,
+					`auctionDuration ${auctionDuration} at ${slotDuration}ms`
+				).to.be.below(
+					CURRENT_SLOT + onChainMaxSlotOffset(auctionDuration, slotDuration)
 				);
 			}
 		}


### PR DESCRIPTION
> **Blocked on [velocity-v1#442](https://github.com/velocity-exchange/velocity-v1/pull/442).** This bumps `@velocity-exchange/sdk` to `0.14.0` (already published) so it builds and tests today, but it is the middle layer of a three-repo rollout: sdk 0.15.0 -> common 0.5.0 -> UI. Publish order is forced because the coupling is by published package, not path link. The UI PR consuming this is `protocol-v2-mono` on the same branch name.

## Summary

The `velocity-common` half of FE-4526. Solana's slot length is dropping 400 -> 350 -> 300 -> 250 -> 200ms through the IBRL feature gates. Every slot count in this package that really encoded a wall-clock intent ("~3 seconds" written as `7`) silently halves in meaning at each gate. This package now receives the live slot duration as an explicit parameter and converts at the read site.

**Design rule:** common does not resolve the live duration itself. Every function whose behavior depends on slot length takes a required `slotDuration: SlotDurationMs`, and the outermost caller resolves it. There is deliberately no resolver, no default value, and no module-level baseline here, because a shared default is wrong for one class of caller at every gate (see the fallback note below).

## Two bugs that are live today, independent of any gate

- **`getIdleWaitTimeMinutes` returns `NaN`.** Published common 0.4.1 was built against sdk 0.10.0 and imports `IDLE_TIME_SLOTS`, which sdk 0.14.0 removed in favour of the wall-clock `IDLE_TIME`. The UI lockfile resolves 0.14.0, so on any fresh install or CI build the import is `undefined` and the DeleteSubaccountModal shows "NaN minutes". Now derived from `IDLE_TIME` directly, matching the wall-clock the program actually gates on in `validation/user.rs`.
- **`getPerpAuctionDuration` diverges from the program right now.** It floored, clamped *slots* to `[5, 180]`, and never converted. The program ceils, clamps *steps* to `[1, 180]`, multiplies by the 400ms unit, converts with the live duration, and caps at 255. The client was predicting a different auction than the chain grants.

## Changes

- **`utils/orders/flags.ts`** — `getPerpAuctionDuration` mirrors `order_params.rs:1025-1053` exactly, including the `min(255)` cap. Takes a required 4th `slotDuration`. **Behavior change at today's 400ms:** the floor moves from 5 slots to 1 step, so a zero-price-diff limit auction now returns `1` where it returned `5`. This is what the program grants; the old value was the divergence. Called out here because it lands on mainnet the moment this publishes, not at a future gate.
- **`accountDeletionHelpers.ts`** — the NaN fix above. `canMakeIdle` also takes the live duration: without it, at 200ms it would report "idle-able" after 30 real minutes while the program requires 60, contradicting the newly-fixed wait estimate sitting next to it.
- **`openSwiftOrder/index.ts`** — the signing guard armed a `setTimeout` of `max(n-5,5) x 400ms`, but the real deadline is a slot (`max_slot = order_slot + auction_duration`). At 200ms it fired twice as late, so the guard failed open and the user signed into a dead window. Now returns an absolute `signingDeadlineSlot` anchored on the prep `currentSlot` (not `orderSlot`, or the buffer double-counts), polled against a caller-supplied `slotSource`, with the live-converted timer kept only as a backstop for a dead feed. `USER_SIGNING_MESSAGE_BUFFER_SLOTS = 7` -> `USER_SIGNING_MESSAGE_BUFFER_MS = 2_800`; the non-auction budget `35` -> `14_000`ms.
- **Deadline clamp.** `signingDeadlineSlot` is now guaranteed strictly inside the auction window for *any* input. Previously the 5-slot minimum floor could exceed a very short window and put the deadline past the auction end, which fails open on a guard whose job is to fail closed. Unreachable through today's call paths, reachable by any caller passing its own small buffer.
- **`SwiftOrderTiming` is surfaced** through `onOrderParamsMessagePrepped`'s second argument, so a consumer showing a signing countdown uses the authoritative window instead of recomputing it and drifting from the guard.
- **`utils/signedMsgs.ts`** — the websocket confirmation give-up was `(n + 15) x 400`. The `+15` is a round-trip allowance, not slots, so it is now `slotsToMsNum(n, live) + SWIFT_CONFIRMATION_ROUND_TRIP_MS`.
- **`positions/open.ts`** — `isOracleValid` was missing its new 5th argument, so `pnlIsClaimable` said no where the chain says yes.
- **`constants/auction.ts`** — `DEFAULT_*_AUCTION_DURATION_MS` (24s / 8s) plus `get...Slots(d)` accessors applying `min(255)`, matching dlob-server. The numeric `60` / `20` names are kept as `@deprecated` aliases so consumers keep compiling.
- **sdk 0.10.0 -> 0.15.0** (now published). The bump broke two test fixtures (`PoolBalance` gained `pendingInterestSplitDust`/`pendingInterestDust`, `PerpMarketAccount` gained `takerFeeAddonTenthBps`/`pendingBankruptcyClaims`); fixed mechanically. The version field is left at 0.4.1: release-please owns it and the feat commit here takes it to 0.5.0.
- **CI guardrail** — a grep step failing if `SLOT_TIME_ESTIMATE_MS` reappears. This repo runs no lint in CI and master has no required checks, so a grep in `ci.yml` is the only enforceable half.

## On the fallback direction

There is no universally safe fallback when the slot feed is dead. Risk ceilings (staleness) are safer assuming a *longer* slot, because the window tightens. User-protection minima (signing windows, expiry countdowns) are safer assuming a *shorter* one, because they under-promise the time left. A single shared constant is wrong for one of the two at every gate. That is why every function here takes the duration explicitly rather than defaulting it, and why the choice is pushed out to the caller that knows which class it is in.

## Testing notes

- `bun run typecheck` clean, `bun run build` clean, `bun run circular-deps` reports no cycles.
- `bun run test:ci`: **175 passing**, up from a 142 baseline. Three new suites in `tests/utils/` (`test:ci` ignores `tests/drift/**`, and `release.yml` runs `test:ci` before publish, so that is the gate that actually blocks).
- Tests are parameterized over `[400, 350, 300, 250, 200]` asserting wall-clock invariance, plus a 400ms identity case per changed site.
- `getPerpAuctionDuration` is checked against the program's own table in `order_params/tests.rs`, including the 255 cap.
- The deadline clamp was verified to have teeth: with the clamp removed the new case fails `expected 1000005 to be below 1000002`; it passes with the clamp restored.
- This repo has no `lint` or `format` script, so those were not run. `build` / `test:ci` / `circular-deps` are the real gates per `common-ts/CLAUDE.md`.

## Reviewer focus

1. The `[5,180]` -> `[1,180]` auction floor change, which is live at 400ms.
2. `getPerpAuctionDuration` uses `isOneOfVariant(contractTier, ['a','b'])` where the program uses `is_as_safe_as_contract(&ContractTier::B)`. Equivalent today, but they would diverge if a tier were ever inserted between B and C. The SDK has no `isAsSafeAsContract` helper to mirror.
3. `getOpenPositionData` takes `slotDuration` as its **5th positional** arg, pushing `markPriceCallback` to 6th (a required param cannot follow an optional one).
4. `src/drift/cli.ts` resolves the duration, now through the SDK's `currentSlotClock`. It is an outermost caller, not library plumbing, so this is the one sanctioned resolver site in the package; it also warns before signing against an assumed slot length. Flag it if you disagree.