### PR TITLE
Add CODEOWNERS for core reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Every change requires review from one of the reviewers below.
+# Ordering rule: the last matching pattern wins.
+
+*	@0xahzam @ChewingGlass @jt-lumen @ChesterSim @csadminlc @noah-velocity-admin


### PR DESCRIPTION
Adds `.github/CODEOWNERS` listing the core reviewers for every path in this repo.

**Effect today:** GitHub automatically requests review from these accounts on any PR. Nothing is blocked.

**To make it enforcing:** enable "Require review from Code Owners" in branch protection for the default branch. That is a separate settings change, not part of this PR.

Reviewers: @0xahzam, @ChewingGlass, @jt-lumen, @ChesterSim, @csadminlc, @noah-velocity-admin. All six were verified to have write access or higher on this repo, so no entry will be silently ignored.
