### PR TITLE
feat(common-ts): add wBTC and wETH spot markets

### DIFF
--- a/common-ts/bun.lock
+++ b/common-ts/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@solana/spl-token": "0.4.14",
         "@solana/web3.js": "1.98.0",
-        "@velocity-exchange/sdk": "0.15.0",
+        "@velocity-exchange/sdk": "0.18.0",
         "bcryptjs-react": "2.4.6",
         "cerializr": "3.1.4",
         "dotenv": "17.4.2",
@@ -391,7 +391,7 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.56.0", "", { "dependencies": { "@typescript-eslint/types": "8.56.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg=="],
 
-    "@velocity-exchange/sdk": ["@velocity-exchange/sdk@0.15.0", "", { "dependencies": { "@anchor-lang/core": "1.0.1", "@coral-xyz/anchor": "npm:@anchor-lang/core@1.0.1", "@coral-xyz/anchor-29": "npm:@coral-xyz/anchor@0.29.0", "@msgpack/msgpack": "3.1.2", "@noble/hashes": "1.7.1", "@pythnetwork/client": "2.5.3", "@pythnetwork/price-service-sdk": "1.7.1", "@pythnetwork/pyth-lazer-sdk": "6.0.0", "@solana/buffer-layout": "4.0.1", "@solana/spl-token": "0.4.13", "@solana/web3.js": "1.98.0", "@triton-one/yellowstone-grpc": "5.0.5", "anchor-bankrun": "0.5.0", "bn.js": "5.2.3", "bs58": "4.0.1", "gill": "0.10.2", "nanoid": "3.3.4", "node-cache": "5.1.2", "node-fetch": "2.7.0", "solana-bankrun": "0.4.0", "strict-event-emitter-types": "2.0.0", "tweetnacl": "1.0.3", "tweetnacl-util": "0.15.1", "uuid": "8.3.2", "ws": "8.18.1", "yargs": "17.7.2", "zod": "4.0.17", "zstddec": "0.1.0" }, "optionalDependencies": { "helius-laserstream": "0.1.8" } }, "sha512-qLUI1eW1N8rqSiVLXlSBRH+nrs0LXWpefS8nDGhoMpxQ6X4Z+FhUCH1meh4l97dji/aLuN0c6PtC7ULpmgpxmg=="],
+    "@velocity-exchange/sdk": ["@velocity-exchange/sdk@0.18.0", "", { "dependencies": { "@anchor-lang/core": "1.0.1", "@coral-xyz/anchor": "npm:@anchor-lang/core@1.0.1", "@coral-xyz/anchor-29": "npm:@coral-xyz/anchor@0.29.0", "@msgpack/msgpack": "3.1.2", "@noble/hashes": "1.7.1", "@pythnetwork/client": "2.5.3", "@pythnetwork/price-service-sdk": "1.7.1", "@pythnetwork/pyth-lazer-sdk": "6.0.0", "@solana/buffer-layout": "4.0.1", "@solana/spl-token": "0.4.13", "@solana/web3.js": "1.98.4", "@triton-one/yellowstone-grpc": "5.0.5", "anchor-bankrun": "0.5.0", "bn.js": "5.2.3", "bs58": "4.0.1", "gill": "0.10.2", "nanoid": "3.3.18", "node-cache": "5.1.2", "node-fetch": "2.7.0", "solana-bankrun": "0.4.0", "strict-event-emitter-types": "2.0.0", "tweetnacl": "1.0.3", "tweetnacl-util": "0.15.1", "uuid": "8.3.2", "ws": "8.21.0", "yargs": "17.7.2", "zod": "4.0.17", "zstddec": "0.1.0" }, "optionalDependencies": { "helius-laserstream": "0.1.8" } }, "sha512-QgwAeEFwmp207fji7wosC7URzvuL//1ZiKHqoI/giRJ5IFGReHJqDkmsjHyltQvaf4dsGE5tvP4t1rVkfZb3Lg=="],
 
     "@vue/compiler-core": ["@vue/compiler-core@3.5.28", "", { "dependencies": { "@babel/parser": "^7.29.0", "@vue/shared": "3.5.28", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-kviccYxTgoE8n6OCw96BNdYlBg2GOWfBuOW4Vqwrt7mSKWKwFVvI8egdTltqRgITGPsTFYtKYfxIG8ptX2PJHQ=="],
 
@@ -1233,7 +1233,7 @@
 
     "write-file-atomic": ["write-file-atomic@4.0.2", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^3.0.7" } }, "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg=="],
 
-    "ws": ["ws@8.18.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
@@ -1429,7 +1429,7 @@
 
     "@velocity-exchange/sdk/bn.js": ["bn.js@5.2.3", "", {}, "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w=="],
 
-    "@velocity-exchange/sdk/nanoid": ["nanoid@3.3.4", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="],
+    "@velocity-exchange/sdk/nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "@velocity-exchange/sdk/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 

--- a/common-ts/package.json
+++ b/common-ts/package.json
@@ -20,7 +20,7 @@
 	"dependencies": {
 		"@solana/spl-token": "0.4.14",
 		"@solana/web3.js": "1.98.0",
-		"@velocity-exchange/sdk": "0.15.0",
+		"@velocity-exchange/sdk": "0.18.0",
 		"bcryptjs-react": "2.4.6",
 		"cerializr": "3.1.4",
 		"dotenv": "17.4.2",

--- a/common-ts/src/actions/actionHelpers/accountDeletionHelpers.ts
+++ b/common-ts/src/actions/actionHelpers/accountDeletionHelpers.ts
@@ -102,7 +102,9 @@ const getAccountCanBeDeletedInstantly = (
 	user: User,
 	userStatsAccount: UserStatsAccount,
 	currentSlot: number,
-	slotDuration: SlotDurationMs
+	// Retained for call-site compatibility; idleness now reads the live slot
+	// duration off the State account instead of a caller-supplied scalar.
+	_slotDuration: SlotDurationMs
 ): CanBeDeletedState => {
 	const statsAccountIsPastDeletionCutoff =
 		getStatsAccountIsPastDeletionCutoff(userStatsAccount);
@@ -111,7 +113,7 @@ const getAccountCanBeDeletedInstantly = (
 
 	const userCanBeMarkedIdle = user.canMakeIdle(
 		new BN(currentSlot),
-		slotDuration
+		user.velocityClient.getStateAccount()
 	);
 
 	const accountHasOpenPerpSpotOrOrders = accountHasOpenPositionsOrOrders(user);
@@ -146,7 +148,8 @@ const getAccountDeletionStepsToTake = (
 	user: User,
 	userStatsAccount: UserStatsAccount,
 	currentSlot: number,
-	slotDuration: SlotDurationMs
+	// Retained for call-site compatibility; see getAccountCanBeDeletedInstantly.
+	_slotDuration: SlotDurationMs
 ): AccountDeletionStep[] => {
 	const userAccount = user.getUserAccountOrThrow();
 	const statsAccountIsPastDeletionCutoff =
@@ -172,7 +175,10 @@ const getAccountDeletionStepsToTake = (
 	}
 
 	// Account can be marked idle and then deleted
-	const canBeMarkedIdle = user.canMakeIdle(new BN(currentSlot), slotDuration);
+	const canBeMarkedIdle = user.canMakeIdle(
+		new BN(currentSlot),
+		user.velocityClient.getStateAccount()
+	);
 
 	if (canBeMarkedIdle) {
 		return ['sendTriggerAccountIdleIx', 'sendAccountDeletionIx'];

--- a/common-ts/src/utils/positions/open.ts
+++ b/common-ts/src/utils/positions/open.ts
@@ -32,7 +32,8 @@ const getOpenPositionData = (
 	slotDuration: SlotDurationMs,
 	markPriceCallback?: (marketIndex: number) => BN
 ): OpenPosition[] => {
-	const oracleGuardRails = velocityClient.getStateAccount().oracleGuardRails;
+	const stateAccount = velocityClient.getStateAccount();
+	const oracleGuardRails = stateAccount.oracleGuardRails;
 
 	const newResult: OpenPosition[] = userPositions
 		.filter(
@@ -174,7 +175,7 @@ const getOpenPositionData = (
 					oraclePriceData,
 					oracleGuardRails,
 					perpMarket.amm.lastUpdateSlot?.toNumber(),
-					slotDuration
+					stateAccount
 				),
 				maxMarginRatio: position.maxMarginRatio,
 			};

--- a/common-ts/src/velocity/base/actions/trade/openPerpOrder/dlobServer/index.ts
+++ b/common-ts/src/velocity/base/actions/trade/openPerpOrder/dlobServer/index.ts
@@ -572,7 +572,7 @@ export async function deriveAuctionParamsFromVamm({
 			marketIndex < 3
 				? MAJORS_TOP_OF_BOOK_QUOTE_AMOUNTS
 				: DEFAULT_TOP_OF_BOOK_QUOTE_AMOUNTS,
-		slotDuration,
+		slotDurationState: velocityClient.getStateAccount(),
 	});
 	const l2Data: L2OrderBook = {
 		bids: createL2Levels(vammGen.getL2Bids(), VAMM_L2_NUM_ORDERS),

--- a/common-ts/tests/orderParams/fetchAuctionOrderParams.test.ts
+++ b/common-ts/tests/orderParams/fetchAuctionOrderParams.test.ts
@@ -438,6 +438,8 @@ describe('fetchAuctionOrderParams', () => {
 			getPerpMarketAccount: (_i: number) => mockPerpMarket,
 			getMMOracleDataForPerpMarket: (_i: number) => mmOracle,
 			getOracleDataForPerpMarket: (_i: number) => oracle,
+			// Empty state resolves to the 400ms baseline slot duration.
+			getStateAccount: () => ({}),
 		} as any;
 	};
 

--- a/common-ts/tests/orderParams/fixtures/rawMockPerpMarkets.ts
+++ b/common-ts/tests/orderParams/fixtures/rawMockPerpMarkets.ts
@@ -223,6 +223,7 @@ function mockPerpMarketCommon(): Omit<
 		takerFeeAddonTenthBps: 0,
 		bankruptcyIfFloorPct: 0,
 		pendingBankruptcyClaims: 0,
+		paddingFuture: [],
 	};
 }
 


### PR DESCRIPTION
## Summary

- Bumps `@velocity-exchange/sdk` to **0.18.0**, which registers **wBTC** (spot market index 2) and **wETH** (index 3) on mainnet. Nothing in `common-ts` enumerates spot markets by hand, so the registry bump is what makes them visible to consumers.
- Migrates the call sites affected by SDK **0.16.0**'s slot-duration change: `canMakeIdle`, `isOracleValid` and `getVammL2Generator` now receive the `State` account instead of a slot-duration scalar.
- Updates two test fixtures for the reserved padding field 0.16.0 added to the perp/spot market accounts.

### The SDK release had a publish gate, and it is satisfied

The SDK changeset that added these markets carried an explicit warning: *"Do not publish this version until the two markets are initialized on chain"* — a client listing markets the chain lacks would subscribe to non-existent accounts. 0.18.0 was published anyway, so I checked mainnet directly before bumping:

| | on-chain | matches SDK registry |
| --- | --- | --- |
| spot 2 | name `wBTC`, mint `3NZ9Jy…qmJh`, 8 decimals | oracle, mint, decimals ✅ |
| spot 3 | name `wETH`, mint `7vfCXT…voxs`, 8 decimals | oracle, mint, decimals ✅ |

Both accounts exist and every field agrees, so the bump is safe.

### Why the slot-duration change is passed the account, not left to default

The new trailing parameter is optional and defaults to the 400ms baseline, so these sites would have compiled clean by simply dropping the argument. That would be wrong: with a live slot length below 400ms the baseline over-states elapsed wall-clock, which makes the client believe an account is idle-eligible before the program does and offer a `markIdle` that fails on chain. Passing the real `State` account keeps the client's prediction matched to the program.

### API compatibility

The exported helper signatures (`getAccountCanBeDeletedInstantly`, `getAccountDeletionStepsToTake`, `getOpenPositionData`) are left positionally intact so the UI and `internal-keeper-bot` do not have to move in lockstep. Their `slotDuration` parameter is now unused and marked as such — a reasonable follow-up is to drop it once consumers are on this version.

This is a `feat`, so release-please should cut **common-ts 0.5.0**.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `oxlint` and `oxfmt --check` clean
- [x] `bun run test` — **177 passing**
- [x] `bun run build` clean
- [x] Verified at runtime that all four mainnet spot markets (USDT, SOL, wBTC, wETH) resolve through `Config.spotMarketsLookup` and construct via `UIMarket` with correct symbols and decimals
- [ ] After publish, bump `@velocity-exchange/sdk` + `@velocity-exchange/common` in `protocol-v2-mono/ui` (that change is prepared and typechecks against this branch)

## Rollout note

The UI cannot pick this up until common is published: it pins the SDK exactly, so bumping only the UI would nest an old SDK under common and leave the markets invisible. Bumping only the UI's SDK is worse — its `resolutions` entry would force common's *current* compiled output onto 0.18, where it passes a plain number to APIs that now expect an object, degrading silently rather than failing loudly.