### PR TITLE
ci: adopt the shared TruffleHog secret scan

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,7 +1,7 @@
 name: Secret scan
 
 # Caller for the org's shared TruffleHog scan. All logic lives in
-# infrastructure-v3/.github/workflows/secret-scan-reusable.yml, so tuning
+# velocity-exchange/shared-workflows, so tuning
 # happens in one place rather than drifting per repo.
 #
 # Scans this PR's own commits (merge-base..head) and fails only on credentials
@@ -16,6 +16,6 @@ permissions:
 
 jobs:
   secret-scan:
-    uses: velocity-exchange/infrastructure-v3/.github/workflows/secret-scan-reusable.yml@master
+    uses: velocity-exchange/shared-workflows/.github/workflows/secret-scan-reusable.yml@master
     with:
       runner: ubicloud

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,21 @@
+name: Secret scan
+
+# Caller for the org's shared TruffleHog scan. All logic lives in
+# infrastructure-v3/.github/workflows/secret-scan-reusable.yml, so tuning
+# happens in one place rather than drifting per repo.
+#
+# Scans this PR's own commits (merge-base..head) and fails only on credentials
+# that verify live against their issuing provider. Unverifiable candidates and
+# possible Solana keypairs are annotated, never blocking.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  secret-scan:
+    uses: velocity-exchange/infrastructure-v3/.github/workflows/secret-scan-reusable.yml@master
+    with:
+      runner: ubicloud


### PR DESCRIPTION
Adopts the org's shared TruffleHog secret scan ([reusable workflow](https://github.com/velocity-exchange/infrastructure-v3/blob/master/.github/workflows/secret-scan-reusable.yml) in infrastructure-v3, so tuning stays in one place).

Scans this PR's own commits (`merge-base..head`), not full history.

| tier | behaviour |
|---|---|
| verified — authenticated against the issuing provider | **fails** |
| unknown — matched, verification inconclusive | annotates |
| possible Solana keypair (64-byte array) | annotates |

Findings report detector + `file:line` only, never the matched value. Runner is `ubicloud` to match this repo's other workflows.

This repo's history was swept at adoption with zero verified secrets, so it should stay silent unless something new lands.