### PR TITLE
feat(common-ts): shorten the swift signing buffer for auto-signing wallets

### DIFF
--- a/common-ts/src/velocity/base/actions/trade/openPerpOrder/openSwiftOrder/index.ts
+++ b/common-ts/src/velocity/base/actions/trade/openPerpOrder/openSwiftOrder/index.ts
@@ -38,9 +38,9 @@ import { Connection } from '@solana/web3.js';
 export const USER_SIGNING_MESSAGE_BUFFER_MS = 2_800;
 
 /**
- * The same budget for a signer that needs no human approval, such as a delegated
- * embedded wallet. It covers the signature, the hop to the SWIFT server and the
- * filler picking the order up, with no prompt to wait on.
+ * The equivalent budget for a signer that needs no human approval, such as a
+ * delegated embedded wallet. It covers the signature, the hop to the SWIFT
+ * server and the filler picking the order up, with no prompt to wait on.
  *
  * This is not only an expiry: the stamped slot is the auction start, and the
  * program refuses to place an auction order before it arrives, so every slot of
@@ -56,6 +56,18 @@ export const DELEGATE_SIGNING_MESSAGE_BUFFER_MS = 800;
  * handling non-auction orders); enforced on chain, so it ceils.
  */
 export const MINIMUM_SWIFT_NON_AUCTION_ORDER_SIGNING_BUDGET_MS = 14_000;
+
+/**
+ * Ceiling on either signing budget.
+ *
+ * The buffer becomes the stamped message slot, and for a resting limit that slot
+ * is a placement deadline the program refuses beyond a 30s lead
+ * (`max_resting_limit_lead` in `place_signed_msg_taker_order`). A budget past
+ * that bound rejects every resting limit on chain, silently, so the tuning knob
+ * is clamped below it rather than trusted. Still leaves room above the 14s
+ * non-auction floor.
+ */
+export const MAXIMUM_SIGNING_MESSAGE_BUFFER_MS = 20_000;
 
 /**
  * The signing budget for this signer, in slots.
@@ -82,7 +94,10 @@ export const getUserSigningSlotBuffer = ({
 		? (budgetMsOverrides?.autoSigned ?? DELEGATE_SIGNING_MESSAGE_BUFFER_MS)
 		: (budgetMsOverrides?.prompted ?? USER_SIGNING_MESSAGE_BUFFER_MS);
 
-	return Math.max(1, msToSlotsCeilNum(budgetMs, slotDuration));
+	return Math.min(
+		Math.max(1, msToSlotsCeilNum(budgetMs, slotDuration)),
+		msToSlotsCeilNum(MAXIMUM_SIGNING_MESSAGE_BUFFER_MS, slotDuration)
+	);
 };
 
 /**

--- a/common-ts/src/velocity/base/actions/trade/openPerpOrder/openSwiftOrder/index.ts
+++ b/common-ts/src/velocity/base/actions/trade/openPerpOrder/openSwiftOrder/index.ts
@@ -38,10 +38,52 @@ import { Connection } from '@solana/web3.js';
 export const USER_SIGNING_MESSAGE_BUFFER_MS = 2_800;
 
 /**
+ * The same budget for a signer that needs no human approval, such as a delegated
+ * embedded wallet. It covers the signature, the hop to the SWIFT server and the
+ * filler picking the order up, with no prompt to wait on.
+ *
+ * This is not only an expiry: the stamped slot is the auction start, and the
+ * program refuses to place an auction order before it arrives, so every slot of
+ * buffer is a slot the auction cannot begin. Under-sizing it is the softer
+ * failure (the auction has already advanced, so the taker starts partway up the
+ * curve) which is why this keeps a margin over the round trip rather than
+ * cutting to the minimum.
+ */
+export const DELEGATE_SIGNING_MESSAGE_BUFFER_MS = 800;
+
+/**
  * Whole approval budget for orders without an auction (kink of the SWIFT server
  * handling non-auction orders); enforced on chain, so it ceils.
  */
 export const MINIMUM_SWIFT_NON_AUCTION_ORDER_SIGNING_BUDGET_MS = 14_000;
+
+/**
+ * The signing budget for this signer, in slots.
+ *
+ * `autoSigned` must mean the signature needs no human approval (a delegated
+ * embedded wallet), not merely that the order is signed by a delegate: a
+ * delegate can still be a wallet that prompts.
+ *
+ * Never returns 0. Callers pass this down through `openPerp*Order`, which use 0
+ * as the "not supplied" sentinel that makes `prepSwiftOrder` fall back to its
+ * own default, so a 0 here would silently restore the full human budget.
+ */
+export const getUserSigningSlotBuffer = ({
+	autoSigned,
+	slotDuration,
+	budgetMsOverrides,
+}: {
+	autoSigned: boolean;
+	slotDuration: SlotDurationMs;
+	/** Per-signer tuning, so a deployment can move either budget without a release. */
+	budgetMsOverrides?: { autoSigned?: number; prompted?: number };
+}): number => {
+	const budgetMs = autoSigned
+		? (budgetMsOverrides?.autoSigned ?? DELEGATE_SIGNING_MESSAGE_BUFFER_MS)
+		: (budgetMsOverrides?.prompted ?? USER_SIGNING_MESSAGE_BUFFER_MS);
+
+	return Math.max(1, msToSlotsCeilNum(budgetMs, slotDuration));
+};
 
 /**
  * Buffer slots from the end of the auction to prevent the signing of the order message.

--- a/common-ts/tests/utils/swiftOrderTiming.test.ts
+++ b/common-ts/tests/utils/swiftOrderTiming.test.ts
@@ -14,6 +14,7 @@ import { expect } from 'chai';
 import {
 	DELEGATE_SIGNING_MESSAGE_BUFFER_MS,
 	getUserSigningSlotBuffer,
+	MAXIMUM_SIGNING_MESSAGE_BUFFER_MS,
 	MINIMUM_SWIFT_NON_AUCTION_ORDER_SIGNING_BUDGET_MS,
 	prepSwiftOrderMessage,
 	USER_SIGNING_MESSAGE_BUFFER_MS,
@@ -284,5 +285,69 @@ describe('user signing slot buffer', () => {
 				budgetMsOverrides: { autoSigned: 2_000 },
 			})
 		).to.equal(5);
+
+		expect(
+			getUserSigningSlotBuffer({
+				autoSigned: false,
+				slotDuration: 400 as SlotDurationMs,
+				budgetMsOverrides: { prompted: 2_000 },
+			})
+		).to.equal(5);
+	});
+
+	it('reads only the override for the branch it took', () => {
+		expect(
+			getUserSigningSlotBuffer({
+				autoSigned: false,
+				slotDuration: 400 as SlotDurationMs,
+				budgetMsOverrides: { autoSigned: 400 },
+			})
+		).to.equal(7);
+
+		expect(
+			getUserSigningSlotBuffer({
+				autoSigned: true,
+				slotDuration: 400 as SlotDurationMs,
+				budgetMsOverrides: { prompted: 40_000 },
+			})
+		).to.equal(2);
+	});
+
+	// The stamped slot is a placement deadline for a resting limit, and the
+	// program refuses one led by more than 30s, so an oversized budget would
+	// reject every resting limit on chain.
+	it('clamps an oversized override below the program lead bound', () => {
+		GATES.forEach((slotDuration) => {
+			const clamped = getUserSigningSlotBuffer({
+				autoSigned: false,
+				slotDuration,
+				budgetMsOverrides: { prompted: 120_000 },
+			});
+
+			expect(clamped).to.equal(
+				Math.ceil(MAXIMUM_SIGNING_MESSAGE_BUFFER_MS / slotDuration)
+			);
+			expect(clamped * slotDuration).to.be.below(30_000);
+		});
+	});
+
+	// The delegate budget is far below the 14s non-auction floor, which
+	// prepSwiftOrder applies after the caller's buffer.
+	it('still floors a resting limit at the non-auction budget', async () => {
+		const restingLimit = await prepSwiftOrderMessage({
+			velocityClient: clientStub(),
+			subAccountId: 0,
+			userAccountPubKey: PublicKey.default,
+			marketIndex: 0,
+			userSigningSlotBuffer: getUserSigningSlotBuffer({
+				autoSigned: true,
+				slotDuration: 400 as SlotDurationMs,
+			}),
+			slotDuration: 400 as SlotDurationMs,
+			orderParams: { main: restingLimitOrder() },
+		});
+
+		expect(restingLimit.slotsTillAuctionEnd).to.equal(35);
+		expect(restingLimit.expirationTimeMs).to.equal(12_000);
 	});
 });

--- a/common-ts/tests/utils/swiftOrderTiming.test.ts
+++ b/common-ts/tests/utils/swiftOrderTiming.test.ts
@@ -12,6 +12,8 @@ import {
 } from '@velocity-exchange/sdk';
 import { expect } from 'chai';
 import {
+	DELEGATE_SIGNING_MESSAGE_BUFFER_MS,
+	getUserSigningSlotBuffer,
 	MINIMUM_SWIFT_NON_AUCTION_ORDER_SIGNING_BUDGET_MS,
 	prepSwiftOrderMessage,
 	USER_SIGNING_MESSAGE_BUFFER_MS,
@@ -229,5 +231,58 @@ describe('getSwiftConfirmationTimeoutMs', () => {
 		expect(
 			getSwiftConfirmationTimeoutMs(10, 2, 200 as SlotDurationMs)
 		).to.equal((10 * 200 + SWIFT_CONFIRMATION_ROUND_TRIP_MS) * 2);
+	});
+});
+
+describe('user signing slot buffer', () => {
+	it('reproduces the legacy 7 slots for a prompting wallet at 400ms', () => {
+		expect(
+			getUserSigningSlotBuffer({
+				autoSigned: false,
+				slotDuration: 400 as SlotDurationMs,
+			})
+		).to.equal(7);
+	});
+
+	it('gives an auto-signer a shorter buffer at every gate', () => {
+		GATES.forEach((slotDuration) => {
+			const autoSigned = getUserSigningSlotBuffer({
+				autoSigned: true,
+				slotDuration,
+			});
+			const prompted = getUserSigningSlotBuffer({
+				autoSigned: false,
+				slotDuration,
+			});
+
+			expect(autoSigned).to.be.below(prompted);
+			expect(autoSigned).to.equal(
+				Math.ceil(DELEGATE_SIGNING_MESSAGE_BUFFER_MS / slotDuration)
+			);
+		});
+	});
+
+	// 0 is the "not supplied" sentinel in openPerp*Order, so returning it would
+	// silently restore the full human budget rather than shorten it.
+	it('never returns the zero sentinel', () => {
+		GATES.forEach((slotDuration) => {
+			expect(
+				getUserSigningSlotBuffer({
+					autoSigned: true,
+					slotDuration,
+					budgetMsOverrides: { autoSigned: 0 },
+				})
+			).to.equal(1);
+		});
+	});
+
+	it('lets an override win over both budgets', () => {
+		expect(
+			getUserSigningSlotBuffer({
+				autoSigned: true,
+				slotDuration: 400 as SlotDurationMs,
+				budgetMsOverrides: { autoSigned: 2_000 },
+			})
+		).to.equal(5);
 	});
 });


### PR DESCRIPTION
## Summary

The swift signing buffer is stamped into the signed message as the **auction start slot**, and since program commit `06877ec48` `place_signed_msg_taker_order` rejects `order_slot > clock.slot`. Fillers therefore hold the order until that slot arrives, so every slot of buffer is a slot the auction cannot begin.

The single budget behind it (`USER_SIGNING_MESSAGE_BUFFER_MS`, 2.8s) was sized for a human approving a wallet prompt. A Privy-delegated embedded wallet never shows one, so delegated traders pay ~2.8s of dead time before their auction can start, on top of an auction start price that is 2.8s stale by the time it opens.

Linear: [FE-4535](https://linear.app/driftprotocol/issue/FE-4535/dynamic-swift-buffer-slots)

## Changes

- Add `DELEGATE_SIGNING_MESSAGE_BUFFER_MS = 800`, the equivalent budget for a signer that needs no human approval. It covers the signature, the hop to the SWIFT server and filler pickup. 800ms is 2 slots at 400ms and 3 at 300ms, against 7 and 10 today.
- Add `getUserSigningSlotBuffer({ autoSigned, slotDuration, budgetMsOverrides })`, which picks the budget and converts at the live slot duration.
- `getUserSigningSlotBuffer` **never returns 0**. `openPerpMarketOrder` and `openPerpNonMarketOrder` both pass `userSigningSlotBuffer ?? 0` down, and `prepSwiftOrder` tests it with `if (!userSigningSlotBuffer)`, so 0 is the reserved "not supplied" sentinel: returning it would silently restore the full 2.8s budget instead of shortening it.
- Add `MAXIMUM_SIGNING_MESSAGE_BUFFER_MS = 20_000` and clamp to it. Since the budget is exposed as a deployment override, and the buffer becomes the stamped slot, a value past the program's 30s `max_resting_limit_lead` would reject **every resting limit on chain, silently**. 20s sits above the 14s non-auction floor and below that bound.

Two deliberate non-changes:

- **`prepSwiftOrder`'s own default is untouched.** It already receives `isDelegate`, but that only means the signer differs from the account authority, and a delegate can still be a prompting wallet. The predicate that actually means "no human" is known to the caller, so the selection stays there.
- **Resting limit orders are unaffected.** For a limit with no auction the buffer is overridden to the 14s non-auction floor, and there the stamped slot is a *placement deadline*, not an auction start. `keep-rs` places those on arrival, so shrinking it buys no latency and only narrows the window the order has to land. Crossing limits carry auction params and do get the improvement. There is now a test asserting this directly.

## Testing notes

8 tests in `swiftOrderTiming.test.ts` cover the helper: the prompting path still yields the legacy 7 slots at 400ms, the auto-signed path is strictly shorter at every slot-duration gate, the zero sentinel is never returned, each branch reads only its own override, an oversized override clamps below the program bound at every gate, and a resting limit still floors at the 14s budget on top of the short delegate buffer.

Full `common-ts` suite: 189 passing. Pre-commit hook (lint, format, typecheck, test, build) passed on both commits.

Under-sizing this value is the softer failure mode: the auction has already advanced, so the taker starts partway up the curve rather than failing. That is why 800ms keeps a margin over the round trip instead of cutting to the minimum. **Worth a second opinion on the number** — 800ms is exactly 2 slots at the 400ms gate, with no rounding slack.

## Follow-up

`protocol-v2-mono` consumes this from npm, so the UI side is blocked on releasing `common-ts` and bumping the dependency. Its PR is #5301, open as a draft.