### PR TITLE
chore(repo): keep common-ts version bumps below 1.0 to minor

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,7 +20,8 @@
 		"common-ts": {
 			"package-name": "@velocity-exchange/common",
 			"component": "common-ts",
-			"changelog-path": "CHANGELOG.md"
+			"changelog-path": "CHANGELOG.md",
+			"bump-minor-pre-major": true
 		},
 		"posthog-types": {
 			"package-name": "@velocity-exchange/posthog-types",


### PR DESCRIPTION
## Why

release-please opened #440 proposing `common-ts 1.0.0`. The cause is the squash-merge setting (`COMMIT_MESSAGES`): the squashed commits for #431 and #432 carried the bodies of every branch commit, two of which had `BREAKING CHANGE:` footers describing changes to the `./format` layer that was itself added in the same PR. Nothing has ever imported that surface, so there is no breaking change for a consumer.

## What

- `Release-As: 0.7.0` in the commit footer, so release-please regenerates the release PR at 0.7.0 instead of 1.0.0.
- `bump-minor-pre-major: true` for `common-ts`, so any future pre-1.0 breaking change bumps the minor rather than the major.

## After merging

release-please updates #440 (or replaces it) with `chore: release common-ts 0.7.0`. Merge that to publish `@velocity-exchange/common@0.7.0`. Do not merge #440 while it still says 1.0.0.
