### PR TITLE
refactor(common-ts): delegate the input-path precision helpers to the format layer

### DIFF
--- a/common-ts/src/format/market.ts
+++ b/common-ts/src/format/market.ts
@@ -128,6 +128,8 @@ export function capStringFractionDigits(
 	cfg: { maxFractionDigits: number }
 ): string {
 	if (typeof input !== 'string' || input === '') return input;
+	if (!Number.isInteger(cfg.maxFractionDigits) || cfg.maxFractionDigits < 0)
+		return input;
 	const separatorIndex = input.lastIndexOf(DECIMAL_SEPARATOR);
 	if (separatorIndex === -1) return input;
 

--- a/common-ts/src/utils/math/precision.ts
+++ b/common-ts/src/utils/math/precision.ts
@@ -1,24 +1,58 @@
-import { BN, SpotMarketConfig } from '@velocity-exchange/sdk';
+import { SpotMarketConfig } from '@velocity-exchange/sdk';
+import {
+	capStringFractionDigits,
+	stepFractionDigits,
+} from '../../format/market';
 
 export const TRADE_PRECISION = 6;
 
+/**
+ * Delegates the digit maths to `capStringFractionDigits`, then restores two
+ * shapes the old slice-based implementation produced and callers still read:
+ * a bare in-progress '.5' keeps its leading separator instead of gaining a '0',
+ * and at zero fraction digits the separator survives ('1.23' -> '1.'), which is
+ * what `roundToStepSize` then strips.
+ *
+ * The head is taken from the LAST separator, the same one the core split on, so
+ * malformed multi-separator input keeps its leading text ('1.2.3' at zero digits
+ * is still '1.2.'). What did move is how many digits such input is allowed:
+ * the old code counted them after the FIRST separator, so '.1.23456' looked
+ * like one fraction digit and survived a two-digit cap; the core counts the five
+ * after the last and caps them to '.1.23'.
+ */
+const capToFractionDigits = (input: string, maxFractionDigits: number) => {
+	const capped = capStringFractionDigits(input, { maxFractionDigits });
+	if (capped === input) return input;
+
+	const sep = input.lastIndexOf('.');
+	const head = input.slice(0, sep);
+	if (maxFractionDigits === 0) return `${head}.`;
+	return sep === 0 ? capped.slice(1) : capped;
+};
+
+/**
+ * @deprecated Use `capStringFractionDigits` from
+ * `@velocity-exchange/common/format`.
+ */
 export const truncateInputToPrecision = (
 	input: string,
 	marketPrecisionExp: SpotMarketConfig['precisionExp']
-) => {
-	const decimalPlaces = input.split('.')[1]?.length ?? 0;
-	const maxDecimals = marketPrecisionExp.toNumber();
+) => capToFractionDigits(input, marketPrecisionExp.toNumber());
 
-	if (decimalPlaces > maxDecimals) {
-		return input.slice(0, input.length - (decimalPlaces - maxDecimals));
-	}
-
-	return input;
-};
-
+/**
+ * @deprecated Use `capStringFractionDigits` with `stepFractionDigits(step)`
+ * from `@velocity-exchange/common/format`.
+ *
+ * The allowed digit count now comes from an exact decimal parse of the step
+ * rather than `Number.prototype.toString`, which stringifies steps below 1e-6
+ * exponentially ('1e-7') and so reported zero decimals: '1.2345678' at a 1e-7
+ * step collapsed to '1'.
+ */
 export const roundToStepSize = (value: string, stepSize?: number) => {
-	const stepSizeExp = stepSize?.toString().split('.')[1]?.length ?? 0;
-	const truncatedValue = truncateInputToPrecision(value, new BN(stepSizeExp));
+	const truncatedValue = capToFractionDigits(
+		value,
+		stepFractionDigits(stepSize)
+	);
 
 	if (truncatedValue.charAt(truncatedValue.length - 1) === '.') {
 		return truncatedValue.slice(0, -1);
@@ -27,6 +61,10 @@ export const roundToStepSize = (value: string, stepSize?: number) => {
 	return truncatedValue;
 };
 
+/**
+ * @deprecated Use `capStringFractionDigits` with `stepFractionDigits(step)`
+ * from `@velocity-exchange/common/format`.
+ */
 export const roundToStepSizeIfLargeEnough = (
 	value: string,
 	stepSize?: number

--- a/common-ts/src/utils/math/precision.ts
+++ b/common-ts/src/utils/math/precision.ts
@@ -1,4 +1,5 @@
 import { SpotMarketConfig } from '@velocity-exchange/sdk';
+import { DECIMAL_SEPARATOR } from '../../format/locale';
 import {
 	capStringFractionDigits,
 	stepFractionDigits,
@@ -24,10 +25,10 @@ const capToFractionDigits = (input: string, maxFractionDigits: number) => {
 	const capped = capStringFractionDigits(input, { maxFractionDigits });
 	if (capped === input) return input;
 
-	const sep = input.lastIndexOf('.');
+	const sep = input.lastIndexOf(DECIMAL_SEPARATOR);
 	const head = input.slice(0, sep);
-	if (maxFractionDigits === 0) return `${head}.`;
-	return sep === 0 ? capped.slice(1) : capped;
+	if (maxFractionDigits === 0) return `${head}${DECIMAL_SEPARATOR}`;
+	return sep === 0 ? capped.slice(DECIMAL_SEPARATOR.length) : capped;
 };
 
 /**

--- a/common-ts/src/utils/math/precision.ts
+++ b/common-ts/src/utils/math/precision.ts
@@ -9,17 +9,8 @@ export const TRADE_PRECISION = 6;
 
 /**
  * Delegates the digit maths to `capStringFractionDigits`, then restores two
- * shapes the old slice-based implementation produced and callers still read:
- * a bare in-progress '.5' keeps its leading separator instead of gaining a '0',
- * and at zero fraction digits the separator survives ('1.23' -> '1.'), which is
- * what `roundToStepSize` then strips.
- *
- * The head is taken from the LAST separator, the same one the core split on, so
- * malformed multi-separator input keeps its leading text ('1.2.3' at zero digits
- * is still '1.2.'). What did move is how many digits such input is allowed:
- * the old code counted them after the FIRST separator, so '.1.23456' looked
- * like one fraction digit and survived a two-digit cap; the core counts the five
- * after the last and caps them to '.1.23'.
+ * shapes callers still read: an in-progress leading separator, and the
+ * trailing separator at zero fraction digits that `roundToStepSize` strips.
  */
 const capToFractionDigits = (input: string, maxFractionDigits: number) => {
 	const capped = capStringFractionDigits(input, { maxFractionDigits });
@@ -45,9 +36,8 @@ export const truncateInputToPrecision = (
  * from `@velocity-exchange/common/format`.
  *
  * The allowed digit count now comes from an exact decimal parse of the step
- * rather than `Number.prototype.toString`, which stringifies steps below 1e-6
- * exponentially ('1e-7') and so reported zero decimals: '1.2345678' at a 1e-7
- * step collapsed to '1'.
+ * instead of `Number.prototype.toString`, which counted the digits of the
+ * exponential string, not of the step, for steps below 1e-6.
  */
 export const roundToStepSize = (value: string, stepSize?: number) => {
 	const truncatedValue = capToFractionDigits(

--- a/common-ts/src/utils/math/precision.ts
+++ b/common-ts/src/utils/math/precision.ts
@@ -13,13 +13,18 @@ export const TRADE_PRECISION = 6;
  * trailing separator at zero fraction digits that `roundToStepSize` strips.
  */
 const capToFractionDigits = (input: string, maxFractionDigits: number) => {
+	if (typeof input !== 'string' || input === '') return input;
+
 	const capped = capStringFractionDigits(input, { maxFractionDigits });
 	if (capped === input) return input;
 
 	const sep = input.lastIndexOf(DECIMAL_SEPARATOR);
-	const head = input.slice(0, sep);
-	if (maxFractionDigits === 0) return `${head}${DECIMAL_SEPARATOR}`;
-	return sep === 0 ? capped.slice(DECIMAL_SEPARATOR.length) : capped;
+	if (maxFractionDigits === 0) {
+		const head = input.slice(0, sep);
+		return `${head}${DECIMAL_SEPARATOR}`;
+	}
+	// slice(1) drops the '0' head the core injects ahead of a leading separator.
+	return sep === 0 ? capped.slice(1) : capped;
 };
 
 /**
@@ -45,7 +50,7 @@ export const roundToStepSize = (value: string, stepSize?: number) => {
 		stepFractionDigits(stepSize)
 	);
 
-	if (truncatedValue.charAt(truncatedValue.length - 1) === '.') {
+	if (truncatedValue.charAt(truncatedValue.length - 1) === DECIMAL_SEPARATOR) {
 		return truncatedValue.slice(0, -1);
 	}
 

--- a/common-ts/tests/format/market.test.ts
+++ b/common-ts/tests/format/market.test.ts
@@ -137,6 +137,30 @@ describe('format/step helpers', () => {
 		);
 	});
 
+	it('capStringFractionDigits returns the input unchanged on an invalid maxFractionDigits', () => {
+		expect(
+			capStringFractionDigits('1.23456', { maxFractionDigits: NaN })
+		).to.equal('1.23456');
+		expect(
+			capStringFractionDigits('1.23456', { maxFractionDigits: -1 })
+		).to.equal('1.23456');
+		expect(
+			capStringFractionDigits('1.23456', { maxFractionDigits: 2.5 })
+		).to.equal('1.23456');
+		expect(
+			capStringFractionDigits('1.23456', { maxFractionDigits: Infinity })
+		).to.equal('1.23456');
+	});
+
+	it('capStringFractionDigits still caps at a valid maxFractionDigits', () => {
+		expect(
+			capStringFractionDigits('1.23456', { maxFractionDigits: 0 })
+		).to.equal('1');
+		expect(
+			capStringFractionDigits('1.23456', { maxFractionDigits: 2 })
+		).to.equal('1.23');
+	});
+
 	it('a 1e-7 step keeps every digit the user typed', () => {
 		const step = d('0.0000001');
 		expect(

--- a/common-ts/tests/format/market.test.ts
+++ b/common-ts/tests/format/market.test.ts
@@ -137,7 +137,7 @@ describe('format/step helpers', () => {
 		);
 	});
 
-	it('capStringFractionDigits returns the input unchanged on an invalid maxFractionDigits', () => {
+	it('capStringFractionDigits pins the maxFractionDigits regressions the guard fixes', () => {
 		expect(
 			capStringFractionDigits('1.23456', { maxFractionDigits: NaN })
 		).to.equal('1.23456');
@@ -147,6 +147,11 @@ describe('format/step helpers', () => {
 		expect(
 			capStringFractionDigits('1.23456', { maxFractionDigits: 2.5 })
 		).to.equal('1.23456');
+	});
+
+	it('capStringFractionDigits also returns the input unchanged on an infinite maxFractionDigits', () => {
+		// Not a regression: fraction.length <= Infinity was always true, so this
+		// case passed through unchanged before the guard existed too.
 		expect(
 			capStringFractionDigits('1.23456', { maxFractionDigits: Infinity })
 		).to.equal('1.23456');

--- a/common-ts/tests/utils/precisionDelegation.test.ts
+++ b/common-ts/tests/utils/precisionDelegation.test.ts
@@ -7,6 +7,9 @@ import {
 import {
 	dividesExactly,
 	numbersFitEvenly,
+	roundToStepSize,
+	roundToStepSizeIfLargeEnough,
+	truncateInputToPrecision,
 } from '../../src/utils/math/precision';
 import { isExactMultiple } from '../../src/format/index';
 import { getDecimalsFromSize } from '../../src/utils/markets/precisions';
@@ -285,6 +288,295 @@ describe('getBigNumRoundedToStepSize delegates to snapValueToStep toward-zero', 
 		expect(() => getBigNumRoundedToStepSize(value, new BN(0))).to.throw(
 			/Cannot snap/
 		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// truncateInputToPrecision / roundToStepSize / roundToStepSizeIfLargeEnough
+// ---------------------------------------------------------------------------
+
+const legacyTruncateInputToPrecision = (input: string, exp: BN) => {
+	const decimalPlaces = input.split('.')[1]?.length ?? 0;
+	const maxDecimals = exp.toNumber();
+	if (decimalPlaces > maxDecimals) {
+		return input.slice(0, input.length - (decimalPlaces - maxDecimals));
+	}
+	return input;
+};
+
+const legacyRoundToStepSize = (value: string, stepSize?: number) => {
+	const stepSizeExp = stepSize?.toString().split('.')[1]?.length ?? 0;
+	const truncated = legacyTruncateInputToPrecision(value, new BN(stepSizeExp));
+	if (truncated.charAt(truncated.length - 1) === '.')
+		return truncated.slice(0, -1);
+	return truncated;
+};
+
+const legacyRoundToStepSizeIfLargeEnough = (
+	value: string,
+	stepSize?: number
+) => {
+	const parsedValue = parseFloat(value);
+	if (isNaN(parsedValue) || stepSize === 0 || !value || parsedValue === 0) {
+		return value;
+	}
+	return legacyRoundToStepSize(value, stepSize);
+};
+
+const INPUT_CORPUS = [
+	'',
+	'abc',
+	'0',
+	'0.0',
+	'1',
+	'1.0',
+	'1.',
+	'.5',
+	'-.5',
+	'.12345',
+	'00.1230',
+	'1.2345678',
+	'-1.2345678',
+	'0.0000001',
+	'-0.0000001',
+	'1e-7',
+	'1,234.5678',
+	'1.2.3',
+	'1.2.345',
+	'.1.23456',
+	'123456789012345.123456789',
+];
+
+const STEP_CORPUS: Array<number | undefined> = [
+	undefined,
+	0,
+	1,
+	2,
+	10,
+	100,
+	0.5,
+	0.1,
+	0.01,
+	0.001,
+	1e-6,
+	1e-7,
+	1e-9,
+	1.5e-7,
+	0.30000000000000004,
+	1e21,
+];
+
+// Neither shape can come from the input path's own keystrokes; both are here
+// because the old and new code disagree on them, so the disagreement is pinned
+// rather than left to be discovered by a caller.
+const MULTI_SEPARATOR =
+	'input holding more than one separator counts its fraction digits after the last one, not the first, so a cap can now bite where it used to pass';
+const NON_STRING =
+	'a non-string value passes through untouched instead of throwing on `.split`, because the delegate type-checks its input first';
+
+const separatorFix = (old: string, next: string): Divergence => ({
+	behaviour: MULTI_SEPARATOR,
+	old,
+	next,
+});
+
+describe('truncateInputToPrecision delegates to capStringFractionDigits', () => {
+	const cases: CorpusCase[] = [];
+	for (const input of INPUT_CORPUS) {
+		for (const exp of [0, 1, 2, 6, 9]) {
+			cases.push({
+				key: `${JSON.stringify(input)} exp ${exp}`,
+				legacy: () => legacyTruncateInputToPrecision(input, new BN(exp)),
+				next: () => truncateInputToPrecision(input, new BN(exp)),
+			});
+		}
+	}
+	cases.push({
+		key: 'non-string 5 exp 6',
+		legacy: () =>
+			legacyTruncateInputToPrecision(5 as unknown as string, new BN(6)),
+		next: () =>
+			String(truncateInputToPrecision(5 as unknown as string, new BN(6))),
+	});
+
+	it('reproduces the slice implementation except at the annotated divergences', () => {
+		runCorpus(cases, {
+			// A single trailing separator is back to the old shape: the head now
+			// comes from the last separator, the same one the core split on.
+			'"1.2.345" exp 0': separatorFix('1.2.34', '1.2.'),
+			'"1.2.345" exp 1': separatorFix('1.2.345', '1.2.3'),
+			'"1.2.345" exp 2': separatorFix('1.2.345', '1.2.34'),
+			'".1.23456" exp 0': separatorFix('.1.2345', '.1.'),
+			'".1.23456" exp 1': separatorFix('.1.23456', '.1.2'),
+			'".1.23456" exp 2': separatorFix('.1.23456', '.1.23'),
+			'non-string 5 exp 6': {
+				behaviour: NON_STRING,
+				old: 'THROWS: input.split is not a function',
+				next: '5',
+			},
+		});
+	});
+
+	it('keeps the in-progress shapes the input path types through', () => {
+		expect(truncateInputToPrecision('1.', new BN(6))).to.equal('1.');
+		expect(truncateInputToPrecision('.5', new BN(6))).to.equal('.5');
+		expect(truncateInputToPrecision('.12345', new BN(2))).to.equal('.12');
+		expect(truncateInputToPrecision('1.23', new BN(0))).to.equal('1.');
+	});
+
+	it('keeps the old head on multi-separator input', () => {
+		expect(legacyTruncateInputToPrecision('1.2.3', new BN(0))).to.equal('1.2.');
+		expect(truncateInputToPrecision('1.2.3', new BN(0))).to.equal('1.2.');
+	});
+});
+
+// The whole point of the delegation: `(1e-7).toString()` is '1e-7', which has
+// no '.', so the old digit count was 0 and every fraction digit was cut.
+const EXPONENTIAL_STEP =
+	'a step below 1e-6, which `Number.prototype.toString` renders exponentially, reports its real decimals instead of zero, so typed fraction digits survive';
+
+const exponentialFix = (old: string, next: string): Divergence => ({
+	behaviour: EXPONENTIAL_STEP,
+	old,
+	next,
+});
+
+const STEP_SIZE_DIVERGENCES: Record<string, Divergence> = {
+	'"0.0" step 1e-7': exponentialFix('0', '0.0'),
+	'"0.0" step 1e-9': exponentialFix('0', '0.0'),
+	'"1.0" step 1e-7': exponentialFix('1', '1.0'),
+	'"1.0" step 1e-9': exponentialFix('1', '1.0'),
+	'".5" step 1e-7': exponentialFix('', '.5'),
+	'".5" step 1e-9': exponentialFix('', '.5'),
+	'"-.5" step 1e-7': exponentialFix('-', '-.5'),
+	'"-.5" step 1e-9': exponentialFix('-', '-.5'),
+	'".12345" step 1e-7': exponentialFix('', '.12345'),
+	'".12345" step 1e-9': exponentialFix('', '.12345'),
+	'".12345" step 1.5e-7': exponentialFix('.1234', '.12345'),
+	'"00.1230" step 1e-7': exponentialFix('00', '00.1230'),
+	'"00.1230" step 1e-9': exponentialFix('00', '00.1230'),
+	'"1.2345678" step 1e-7': exponentialFix('1', '1.2345678'),
+	'"1.2345678" step 1e-9': exponentialFix('1', '1.2345678'),
+	'"1.2345678" step 1.5e-7': exponentialFix('1.2345', '1.2345678'),
+	'"-1.2345678" step 1e-7': exponentialFix('-1', '-1.2345678'),
+	'"-1.2345678" step 1e-9': exponentialFix('-1', '-1.2345678'),
+	'"-1.2345678" step 1.5e-7': exponentialFix('-1.2345', '-1.2345678'),
+	'"0.0000001" step 1e-7': exponentialFix('0', '0.0000001'),
+	'"0.0000001" step 1e-9': exponentialFix('0', '0.0000001'),
+	'"0.0000001" step 1.5e-7': exponentialFix('0.0000', '0.0000001'),
+	'"-0.0000001" step 1e-7': exponentialFix('-0', '-0.0000001'),
+	'"-0.0000001" step 1e-9': exponentialFix('-0', '-0.0000001'),
+	'"-0.0000001" step 1.5e-7': exponentialFix('-0.0000', '-0.0000001'),
+	'"1,234.5678" step 1e-7': exponentialFix('1,234', '1,234.5678'),
+	'"1,234.5678" step 1e-9': exponentialFix('1,234', '1,234.5678'),
+	// Multi-separator input at an exponential step: the digit count, not the
+	// head, is what moved, so these belong to the same fix.
+	'"1.2.3" step 1e-7': exponentialFix('1.2', '1.2.3'),
+	'"1.2.3" step 1e-9': exponentialFix('1.2', '1.2.3'),
+	'"1.2.345" step 1e-7': exponentialFix('1.2.34', '1.2.345'),
+	'"1.2.345" step 1e-9': exponentialFix('1.2.34', '1.2.345'),
+	'".1.23456" step 1e-7': exponentialFix('.1.2345', '.1.23456'),
+	'".1.23456" step 1e-9': exponentialFix('.1.2345', '.1.23456'),
+	'"123456789012345.123456789" step 1e-7': exponentialFix(
+		'123456789012345',
+		'123456789012345.1234567'
+	),
+	'"123456789012345.123456789" step 1e-9': exponentialFix(
+		'123456789012345',
+		'123456789012345.123456789'
+	),
+	'"123456789012345.123456789" step 1.5e-7': exponentialFix(
+		'123456789012345.1234',
+		'123456789012345.12345678'
+	),
+	// '1.2.3' is absent from here on: at every plainly stringified step it now
+	// reproduces the old output exactly.
+	'"1.2.345" step undefined': separatorFix('1.2.34', '1.2'),
+	'"1.2.345" step 0': separatorFix('1.2.34', '1.2'),
+	'"1.2.345" step 1': separatorFix('1.2.34', '1.2'),
+	'"1.2.345" step 2': separatorFix('1.2.34', '1.2'),
+	'"1.2.345" step 10': separatorFix('1.2.34', '1.2'),
+	'"1.2.345" step 100': separatorFix('1.2.34', '1.2'),
+	'"1.2.345" step 1e+21': separatorFix('1.2.34', '1.2'),
+	'"1.2.345" step 0.5': separatorFix('1.2.345', '1.2.3'),
+	'"1.2.345" step 0.1': separatorFix('1.2.345', '1.2.3'),
+	'"1.2.345" step 0.01': separatorFix('1.2.345', '1.2.34'),
+	'".1.23456" step undefined': separatorFix('.1.2345', '.1'),
+	'".1.23456" step 0': separatorFix('.1.2345', '.1'),
+	'".1.23456" step 1': separatorFix('.1.2345', '.1'),
+	'".1.23456" step 2': separatorFix('.1.2345', '.1'),
+	'".1.23456" step 10': separatorFix('.1.2345', '.1'),
+	'".1.23456" step 100': separatorFix('.1.2345', '.1'),
+	'".1.23456" step 1e+21': separatorFix('.1.2345', '.1'),
+	'".1.23456" step 0.5': separatorFix('.1.23456', '.1.2'),
+	'".1.23456" step 0.1': separatorFix('.1.23456', '.1.2'),
+	'".1.23456" step 0.01': separatorFix('.1.23456', '.1.23'),
+	'".1.23456" step 0.001': separatorFix('.1.23456', '.1.234'),
+};
+
+describe('roundToStepSize delegates to capStringFractionDigits with an exact step', () => {
+	const cases: CorpusCase[] = [];
+	for (const input of INPUT_CORPUS) {
+		for (const step of STEP_CORPUS) {
+			cases.push({
+				key: `${JSON.stringify(input)} step ${step}`,
+				legacy: () => legacyRoundToStepSize(input, step),
+				next: () => roundToStepSize(input, step),
+			});
+		}
+	}
+
+	it('reproduces the slice implementation except at the annotated fixes', () => {
+		runCorpus(cases, STEP_SIZE_DIVERGENCES);
+	});
+
+	it('keeps the fraction digits of a step that stringifies exponentially', () => {
+		expect(legacyRoundToStepSize('1.2345678', 1e-7)).to.equal('1');
+		expect(roundToStepSize('1.2345678', 1e-7)).to.equal('1.2345678');
+		expect(legacyRoundToStepSize('1.2345678', 1e-9)).to.equal('1');
+		expect(roundToStepSize('1.2345678', 1e-9)).to.equal('1.2345678');
+	});
+
+	it('leaves every step that stringifies plainly untouched', () => {
+		expect(roundToStepSize('1.2345678', 1e-6)).to.equal('1.234567');
+		expect(roundToStepSize('1.2345678', 0.01)).to.equal('1.23');
+		expect(roundToStepSize('1.2345678', 1)).to.equal('1');
+		expect(roundToStepSize('1.2345678', 100)).to.equal('1');
+	});
+});
+
+describe('roundToStepSizeIfLargeEnough keeps its guard and inherits the step fix', () => {
+	const cases: CorpusCase[] = [];
+	for (const input of INPUT_CORPUS) {
+		for (const step of STEP_CORPUS) {
+			cases.push({
+				key: `${JSON.stringify(input)} step ${step}`,
+				legacy: () => legacyRoundToStepSizeIfLargeEnough(input, step),
+				next: () => roundToStepSizeIfLargeEnough(input, step),
+			});
+		}
+	}
+
+	// '0' and '0.0' short-circuit on the parsedValue === 0 guard, '' on the
+	// falsy-value guard and 'abc' on the NaN guard, and a zero step returns the
+	// value untouched, so none of those reach roundToStepSize at all.
+	const GUARDED_INPUTS = ['', 'abc', '0', '0.0'];
+	const divergences: Record<string, Divergence> = {};
+	for (const [key, divergence] of Object.entries(STEP_SIZE_DIVERGENCES)) {
+		const [rawInput, rawStep] = key.split('" step ');
+		if (GUARDED_INPUTS.includes(rawInput.slice(1))) continue;
+		if (Number(rawStep) === 0) continue;
+		divergences[key] = divergence;
+	}
+
+	it('reproduces the guard exactly and only differs where roundToStepSize does', () => {
+		runCorpus(cases, divergences);
+	});
+
+	it('returns the value untouched wherever the guard fires', () => {
+		expect(roundToStepSizeIfLargeEnough('0.0', 1e-7)).to.equal('0.0');
+		expect(roundToStepSizeIfLargeEnough('1.2.345', 0)).to.equal('1.2.345');
+		expect(roundToStepSizeIfLargeEnough('abc', 1e-7)).to.equal('abc');
 	});
 });
 

--- a/common-ts/tests/utils/precisionDelegation.test.ts
+++ b/common-ts/tests/utils/precisionDelegation.test.ts
@@ -398,6 +398,38 @@ describe('truncateInputToPrecision delegates to capStringFractionDigits', () => 
 		next: () =>
 			String(truncateInputToPrecision(5 as unknown as string, new BN(6))),
 	});
+	cases.push({
+		key: '"1234.5678" exp -1',
+		legacy: () => legacyTruncateInputToPrecision('1234.5678', new BN(-1)),
+		next: () => truncateInputToPrecision('1234.5678', new BN(-1)),
+	});
+	cases.push({
+		key: '"1234.5678" exp NaN',
+		legacy: () =>
+			legacyTruncateInputToPrecision('1234.5678', {
+				toNumber: () => NaN,
+			} as unknown as BN),
+		next: () =>
+			truncateInputToPrecision('1234.5678', {
+				toNumber: () => NaN,
+			} as unknown as BN),
+	});
+
+	it('throws on 5 as a non-string, both old and new, and unwinds to the same input', () => {
+		expect(() =>
+			legacyRoundToStepSize(5 as unknown as string, 0.01)
+		).to.throw();
+		expect(() => roundToStepSize(5 as unknown as string, 0.01)).to.throw();
+		expect(() =>
+			legacyRoundToStepSizeIfLargeEnough(5 as unknown as string, 0.01)
+		).to.throw();
+		expect(() =>
+			roundToStepSizeIfLargeEnough(5 as unknown as string, 0.01)
+		).to.throw();
+		expect(
+			truncateInputToPrecision(5 as unknown as string, new BN(6))
+		).to.equal(5);
+	});
 
 	it('reproduces the slice implementation except at the annotated divergences', () => {
 		runCorpus(cases, {
@@ -413,6 +445,12 @@ describe('truncateInputToPrecision delegates to capStringFractionDigits', () => 
 				behaviour: NON_STRING,
 				old: 'THROWS: input.split is not a function',
 				next: '5',
+			},
+			'"1234.5678" exp -1': {
+				behaviour:
+					'a negative maxFractionDigits is invalid input and now leaves the value untouched, instead of the old arithmetic cutting into the integer part',
+				old: '1234',
+				next: '1234.5678',
 			},
 		});
 	});

--- a/common-ts/tests/utils/precisionDelegation.test.ts
+++ b/common-ts/tests/utils/precisionDelegation.test.ts
@@ -345,6 +345,11 @@ const INPUT_CORPUS = [
 	'1.2.345',
 	'.1.23456',
 	'123456789012345.123456789',
+	// A long first fraction segment ahead of a second separator: the old head
+	// comes from the first separator, the new one from the last, and here that
+	// makes the new value longer than the old, not shorter.
+	'1.23456.7',
+	'9.99999.9',
 ];
 
 const STEP_CORPUS: Array<number | undefined> = [
@@ -364,6 +369,11 @@ const STEP_CORPUS: Array<number | undefined> = [
 	1.5e-7,
 	0.30000000000000004,
 	1e21,
+	-1,
+	-0.01,
+	-1e-7,
+	NaN,
+	Infinity,
 ];
 
 // Neither shape can come from the input path's own keystrokes; both are here
@@ -371,11 +381,19 @@ const STEP_CORPUS: Array<number | undefined> = [
 // rather than left to be discovered by a caller.
 const MULTI_SEPARATOR =
 	'input holding more than one separator counts its fraction digits after the last one, not the first, so a cap can now bite where it used to pass';
+const MULTI_SEPARATOR_GROWS =
+	'master truncated into the first fraction from the wrong separator; the delegate keeps every digit up to the cap counted from the last separator, so the parsed value can move upward toward what was typed';
 const NON_STRING =
 	'a non-string value passes through untouched instead of throwing on `.split`, because the delegate type-checks its input first';
 
 const separatorFix = (old: string, next: string): Divergence => ({
 	behaviour: MULTI_SEPARATOR,
+	old,
+	next,
+});
+
+const separatorGrows = (old: string, next: string): Divergence => ({
+	behaviour: MULTI_SEPARATOR_GROWS,
 	old,
 	next,
 });
@@ -414,6 +432,17 @@ describe('truncateInputToPrecision delegates to capStringFractionDigits', () => 
 				toNumber: () => NaN,
 			} as unknown as BN),
 	});
+	cases.push({
+		key: '"1234.5678" exp 2.5',
+		legacy: () =>
+			legacyTruncateInputToPrecision('1234.5678', {
+				toNumber: () => 2.5,
+			} as unknown as BN),
+		next: () =>
+			truncateInputToPrecision('1234.5678', {
+				toNumber: () => 2.5,
+			} as unknown as BN),
+	});
 
 	it('throws on 5 as a non-string, both old and new, and unwinds to the same input', () => {
 		expect(() =>
@@ -429,6 +458,8 @@ describe('truncateInputToPrecision delegates to capStringFractionDigits', () => 
 		expect(
 			truncateInputToPrecision(5 as unknown as string, new BN(6))
 		).to.equal(5);
+		expect(truncateInputToPrecision(NaN as unknown as string, new BN(6))).to.be
+			.NaN;
 	});
 
 	it('reproduces the slice implementation except at the annotated divergences', () => {
@@ -441,6 +472,12 @@ describe('truncateInputToPrecision delegates to capStringFractionDigits', () => 
 			'".1.23456" exp 0': separatorFix('.1.2345', '.1.'),
 			'".1.23456" exp 1': separatorFix('.1.23456', '.1.2'),
 			'".1.23456" exp 2': separatorFix('.1.23456', '.1.23'),
+			'"1.23456.7" exp 0': separatorGrows('1.23', '1.23456.'),
+			'"1.23456.7" exp 1': separatorGrows('1.234', '1.23456.7'),
+			'"1.23456.7" exp 2': separatorGrows('1.2345', '1.23456.7'),
+			'"9.99999.9" exp 0': separatorGrows('9.99', '9.99999.'),
+			'"9.99999.9" exp 1': separatorGrows('9.999', '9.99999.9'),
+			'"9.99999.9" exp 2': separatorGrows('9.9999', '9.99999.9'),
 			'non-string 5 exp 6': {
 				behaviour: NON_STRING,
 				old: 'THROWS: input.split is not a function',
@@ -450,6 +487,12 @@ describe('truncateInputToPrecision delegates to capStringFractionDigits', () => 
 				behaviour:
 					'a negative maxFractionDigits is invalid input and now leaves the value untouched, instead of the old arithmetic cutting into the integer part',
 				old: '1234',
+				next: '1234.5678',
+			},
+			'"1234.5678" exp 2.5': {
+				behaviour:
+					'a non-integer maxFractionDigits is invalid input and now leaves the value untouched, instead of the old arithmetic slicing at a fractional string index',
+				old: '1234.56',
 				next: '1234.5678',
 			},
 		});
@@ -550,6 +593,75 @@ const STEP_SIZE_DIVERGENCES: Record<string, Divergence> = {
 	'".1.23456" step 0.1': separatorFix('.1.23456', '.1.2'),
 	'".1.23456" step 0.01': separatorFix('.1.23456', '.1.23'),
 	'".1.23456" step 0.001': separatorFix('.1.23456', '.1.234'),
+	// A long first fraction ahead of a second separator: the delegate keeps
+	// digits master threw away, so the new value is longer, not shorter.
+	'"1.23456.7" step undefined': separatorGrows('1.23', '1.23456'),
+	'"1.23456.7" step 0': separatorGrows('1.23', '1.23456'),
+	'"1.23456.7" step 1': separatorGrows('1.23', '1.23456'),
+	'"1.23456.7" step 2': separatorGrows('1.23', '1.23456'),
+	'"1.23456.7" step 10': separatorGrows('1.23', '1.23456'),
+	'"1.23456.7" step 100': separatorGrows('1.23', '1.23456'),
+	'"1.23456.7" step 1e+21': separatorGrows('1.23', '1.23456'),
+	'"1.23456.7" step 0.5': separatorGrows('1.234', '1.23456.7'),
+	'"1.23456.7" step 0.1': separatorGrows('1.234', '1.23456.7'),
+	'"1.23456.7" step 0.01': separatorGrows('1.2345', '1.23456.7'),
+	'"1.23456.7" step 0.001': separatorGrows('1.23456', '1.23456.7'),
+	'"1.23456.7" step 1e-7': separatorGrows('1.23', '1.23456.7'),
+	'"1.23456.7" step 1e-9': separatorGrows('1.23', '1.23456.7'),
+	'"1.23456.7" step 1.5e-7': separatorGrows('1.23456', '1.23456.7'),
+	'"9.99999.9" step undefined': separatorGrows('9.99', '9.99999'),
+	'"9.99999.9" step 0': separatorGrows('9.99', '9.99999'),
+	'"9.99999.9" step 1': separatorGrows('9.99', '9.99999'),
+	'"9.99999.9" step 2': separatorGrows('9.99', '9.99999'),
+	'"9.99999.9" step 10': separatorGrows('9.99', '9.99999'),
+	'"9.99999.9" step 100': separatorGrows('9.99', '9.99999'),
+	'"9.99999.9" step 1e+21': separatorGrows('9.99', '9.99999'),
+	'"9.99999.9" step 0.5': separatorGrows('9.999', '9.99999.9'),
+	'"9.99999.9" step 0.1': separatorGrows('9.999', '9.99999.9'),
+	'"9.99999.9" step 0.01': separatorGrows('9.9999', '9.99999.9'),
+	'"9.99999.9" step 0.001': separatorGrows('9.99999', '9.99999.9'),
+	'"9.99999.9" step 1e-7': separatorGrows('9.99', '9.99999.9'),
+	'"9.99999.9" step 1e-9': separatorGrows('9.99', '9.99999.9'),
+	'"9.99999.9" step 1.5e-7': separatorGrows('9.99999', '9.99999.9'),
+	// A negative or non-finite step: `stepFractionDigits` reads its magnitude
+	// the same as the plain step it mirrors, so these reproduce that step's
+	// divergence values exactly, just under a step-side sign or non-finite key.
+	'"1.2.345" step -1': separatorFix('1.2.34', '1.2'),
+	'".1.23456" step -1': separatorFix('.1.2345', '.1'),
+	'"1.23456.7" step -1': separatorGrows('1.23', '1.23456'),
+	'"9.99999.9" step -1': separatorGrows('9.99', '9.99999'),
+	'"1.2.345" step -0.01': separatorFix('1.2.345', '1.2.34'),
+	'".1.23456" step -0.01': separatorFix('.1.23456', '.1.23'),
+	'"1.23456.7" step -0.01': separatorGrows('1.2345', '1.23456.7'),
+	'"9.99999.9" step -0.01': separatorGrows('9.9999', '9.99999.9'),
+	'"0.0" step -1e-7': exponentialFix('0', '0.0'),
+	'"1.0" step -1e-7': exponentialFix('1', '1.0'),
+	'".5" step -1e-7': exponentialFix('', '.5'),
+	'"-.5" step -1e-7': exponentialFix('-', '-.5'),
+	'".12345" step -1e-7': exponentialFix('', '.12345'),
+	'"00.1230" step -1e-7': exponentialFix('00', '00.1230'),
+	'"1.2345678" step -1e-7': exponentialFix('1', '1.2345678'),
+	'"-1.2345678" step -1e-7': exponentialFix('-1', '-1.2345678'),
+	'"0.0000001" step -1e-7': exponentialFix('0', '0.0000001'),
+	'"-0.0000001" step -1e-7': exponentialFix('-0', '-0.0000001'),
+	'"1,234.5678" step -1e-7': exponentialFix('1,234', '1,234.5678'),
+	'"1.2.3" step -1e-7': exponentialFix('1.2', '1.2.3'),
+	'"1.2.345" step -1e-7': exponentialFix('1.2.34', '1.2.345'),
+	'".1.23456" step -1e-7': exponentialFix('.1.2345', '.1.23456'),
+	'"123456789012345.123456789" step -1e-7': exponentialFix(
+		'123456789012345',
+		'123456789012345.1234567'
+	),
+	'"1.23456.7" step -1e-7': separatorGrows('1.23', '1.23456.7'),
+	'"9.99999.9" step -1e-7': separatorGrows('9.99', '9.99999.9'),
+	'"1.2.345" step NaN': separatorFix('1.2.34', '1.2'),
+	'".1.23456" step NaN': separatorFix('.1.2345', '.1'),
+	'"1.23456.7" step NaN': separatorGrows('1.23', '1.23456'),
+	'"9.99999.9" step NaN': separatorGrows('9.99', '9.99999'),
+	'"1.2.345" step Infinity': separatorFix('1.2.34', '1.2'),
+	'".1.23456" step Infinity': separatorFix('.1.2345', '.1'),
+	'"1.23456.7" step Infinity': separatorGrows('1.23', '1.23456'),
+	'"9.99999.9" step Infinity': separatorGrows('9.99', '9.99999'),
 };
 
 describe('roundToStepSize delegates to capStringFractionDigits with an exact step', () => {


### PR DESCRIPTION
**Do not merge until protocol-v2-mono #5304 is merged**

## What delegates to what

The three input-path helpers in `common-ts/src/utils/math/precision.ts` stop doing
their own string slicing and take their digit maths from the exact-decimal format
layer that landed in #431 / #432.

| Helper | Now delegates to |
| --- | --- |
| `truncateInputToPrecision(input, precisionExp)` | `capStringFractionDigits(input, { maxFractionDigits: precisionExp.toNumber() })` |
| `roundToStepSize(value, stepSize)` | `capStringFractionDigits(value, { maxFractionDigits: stepFractionDigits(stepSize) })`, then the existing trailing-separator strip |
| `roundToStepSizeIfLargeEnough(value, stepSize)` | its own guard, unchanged, then `roundToStepSize` |

A small local `capToFractionDigits` adapter sits between them and the format layer.
It restores two shapes the old slice-based code produced and callers still read:

- a bare in-progress `.5` keeps its leading separator instead of gaining a `0`;
- at zero fraction digits the separator survives (`'1.23'` -> `'1.'`), which is
  exactly what `roundToStepSize` then strips.

Every exported name and signature is unchanged. `numbersFitEvenly`, `dividesExactly`,
`valueIsBelowStepSize` and the orderbook code are untouched. The three delegating
helpers carry `@deprecated` tags pointing at `capStringFractionDigits` and
`stepFractionDigits` on `@velocity-exchange/common/format`.

The second commit adds the characterization corpora to
`common-ts/tests/utils/precisionDelegation.test.ts`, run against inline copies of
the pre-delegation implementations through the shared `runCorpus` helper. The runner
fails both on an unlisted disagreement and on a listed one that is never reached, so
the list below is exhaustive over the corpora and cannot go stale.

## Behaviour changes that need sign-off

### 1. A step below 1e-6 no longer reports zero decimals

`(1e-7).toString()` is `'1e-7'`, which has no `.`, so the old
`stepSize?.toString().split('.')[1]?.length ?? 0` returned 0 and every typed
fraction digit was cut. `stepFractionDigits` parses the step exactly instead.

Affected step values in the corpus: `1e-7`, `1e-9`, `1.5e-7`. Every other step
tested (`undefined`, `0`, `1`, `2`, `10`, `100`, `0.5`, `0.1`, `0.01`, `0.001`,
`1e-6`, `0.30000000000000004`, `1e21`) is byte-for-byte unchanged.

`roundToStepSize` / `roundToStepSizeIfLargeEnough`:

| value | step | old | new |
| --- | --- | --- | --- |
| `1.2345678` | `1e-7` | `1` | `1.2345678` |
| `1.2345678` | `1e-9` | `1` | `1.2345678` |
| `1.2345678` | `1.5e-7` | `1.2345` | `1.2345678` |
| `-1.2345678` | `1e-7` | `-1` | `-1.2345678` |
| `-1.2345678` | `1e-9` | `-1` | `-1.2345678` |
| `-1.2345678` | `1.5e-7` | `-1.2345` | `-1.2345678` |
| `0.0000001` | `1e-7` | `0` | `0.0000001` |
| `0.0000001` | `1e-9` | `0` | `0.0000001` |
| `0.0000001` | `1.5e-7` | `0.0000` | `0.0000001` |
| `-0.0000001` | `1e-7` | `-0` | `-0.0000001` |
| `-0.0000001` | `1e-9` | `-0` | `-0.0000001` |
| `-0.0000001` | `1.5e-7` | `-0.0000` | `-0.0000001` |
| `1.0` | `1e-7` / `1e-9` | `1` | `1.0` |
| `00.1230` | `1e-7` / `1e-9` | `00` | `00.1230` |
| `.5` | `1e-7` / `1e-9` | `` (empty) | `.5` |
| `-.5` | `1e-7` / `1e-9` | `-` | `-.5` |
| `.12345` | `1e-7` / `1e-9` | `` (empty) | `.12345` |
| `.12345` | `1.5e-7` | `.1234` | `.12345` |
| `1,234.5678` | `1e-7` / `1e-9` | `1,234` | `1,234.5678` |
| `123456789012345.123456789` | `1e-7` | `123456789012345` | `123456789012345.1234567` |
| `123456789012345.123456789` | `1e-9` | `123456789012345` | `123456789012345.123456789` |
| `123456789012345.123456789` | `1.5e-7` | `123456789012345.1234` | `123456789012345.12345678` |

`roundToStepSize` additionally moves on `'0.0'` at `1e-7` / `1e-9` (`'0'` -> `'0.0'`);
`roundToStepSizeIfLargeEnough` does not, because its `parsedValue === 0` guard fires
first and returns the value untouched.

A negative or non-finite step (`-1e-7`, `NaN`, `Infinity`) reads its magnitude the
same way, so it reproduces the same divergence values as the plain step it mirrors;
those are pinned under their own step-value keys in the corpus rather than assumed.

**No live mainnet or devnet market has a step size or tick size below 1e-6 today**,
so this branch is unreachable with current on-chain config. It is here so a future
market with a finer step does not silently eat the trader's digits.

`stepFractionDigits` also ignores trailing zeros of a string step:
`stepFractionDigits('0.010')` reports 2 digits, where the old
`'0.010'.split('.')[1].length` gave 3. This is unreachable through the three
deprecated helpers here, since their `stepSize` parameter is typed as `number` and
`(0.01).toString()` never carries a trailing zero; it only matters to a direct
caller of `stepFractionDigits` with a string step.

### 2. Malformed multi-separator input counts its digits after the LAST separator, and the head or the parsed value can move in either direction

Input holding more than one `.` cannot come from the input path's own keystrokes, but
the old and new code disagree on it, so it is pinned rather than left to be discovered
by a caller. The old code counted fraction digits after the FIRST separator; the format
core counts after the last one, the same one it splits the head on.

Usually this makes the new value shorter, because the old code was undercounting how
much to cut: the head itself is unchanged (`'1.2.3'` at zero digits is still `'1.2.'`).
But when the segment before the last separator is long and the segment after it is
short, the direction flips: master truncated into the first fraction from the wrong
separator, while the delegate keeps every digit up to the cap counted from the last
separator, so the new value is longer and the parsed number can move upward toward
what was actually typed.

`truncateInputToPrecision`:

| input | precisionExp | old | new |
| --- | --- | --- | --- |
| `1.2.345` | 0 | `1.2.34` | `1.2.` |
| `1.2.345` | 1 | `1.2.345` | `1.2.3` |
| `1.2.345` | 2 | `1.2.345` | `1.2.34` |
| `.1.23456` | 0 | `.1.2345` | `.1.` |
| `.1.23456` | 1 | `.1.23456` | `.1.2` |
| `.1.23456` | 2 | `.1.23456` | `.1.23` |
| `1.23456.7` | 0 | `1.23` | `1.23456.` |
| `1.23456.7` | 1 | `1.234` | `1.23456.7` |
| `1.23456.7` | 2 | `1.2345` | `1.23456.7` |
| `9.99999.9` | 0 | `9.99` | `9.99999.` |
| `9.99999.9` | 1 | `9.999` | `9.99999.9` |
| `9.99999.9` | 2 | `9.9999` | `9.99999.9` |

`roundToStepSize` / `roundToStepSizeIfLargeEnough` (same cause, step-derived digit count):

| value | step | old | new |
| --- | --- | --- | --- |
| `1.2.345` | `undefined`, `0`, `1`, `2`, `10`, `100`, `1e+21` | `1.2.34` | `1.2` |
| `1.2.345` | `0.5`, `0.1` | `1.2.345` | `1.2.3` |
| `1.2.345` | `0.01` | `1.2.345` | `1.2.34` |
| `1.2.345` | `1e-7`, `1e-9` | `1.2.34` | `1.2.345` |
| `.1.23456` | `undefined`, `0`, `1`, `2`, `10`, `100`, `1e+21` | `.1.2345` | `.1` |
| `.1.23456` | `0.5`, `0.1` | `.1.23456` | `.1.2` |
| `.1.23456` | `0.01` | `.1.23456` | `.1.23` |
| `.1.23456` | `0.001` | `.1.23456` | `.1.234` |
| `.1.23456` | `1e-7`, `1e-9` | `.1.2345` | `.1.23456` |
| `1.2.3` | `1e-7`, `1e-9` | `1.2` | `1.2.3` |
| `1.23456.7` | `undefined`, `0`, `1`, `2`, `10`, `100`, `1e+21` | `1.23` | `1.23456` |
| `1.23456.7` | `0.5`, `0.1` | `1.234` | `1.23456.7` |
| `1.23456.7` | `0.01` | `1.2345` | `1.23456.7` |
| `1.23456.7` | `0.001` | `1.23456` | `1.23456.7` |
| `1.23456.7` | `1e-7`, `1e-9` | `1.23` | `1.23456.7` |
| `9.99999.9` | `undefined`, `0`, `1`, `2`, `10`, `100`, `1e+21` | `9.99` | `9.99999` |
| `9.99999.9` | `0.5`, `0.1` | `9.999` | `9.99999.9` |
| `9.99999.9` | `0.01` | `9.9999` | `9.99999.9` |
| `9.99999.9` | `0.001` | `9.99999` | `9.99999.9` |
| `9.99999.9` | `1e-7`, `1e-9` | `9.99` | `9.99999.9` |

(`1.2.3`, `1.23456.7` and `9.99999.9` match the old output at every plainly
stringified step; only the exponential steps move them.)

`roundToStepSizeIfLargeEnough` does not diverge at step `0`, where its guard returns the
value untouched.

### 3. Only `truncateInputToPrecision` stops throwing on non-string input

`truncateInputToPrecision(5 as unknown as string, new BN(6))` used to throw
`TypeError: input.split is not a function`; it now returns `5` unchanged, because
`capStringFractionDigits` type-checks its input before touching it. The same holds
for a `NaN` input: it now comes back as `NaN`, unchanged, instead of throwing.

`roundToStepSize` and `roundToStepSizeIfLargeEnough` still throw on the same
non-string input, just with a different message: `capToFractionDigits` gets the
untouched value back from `capStringFractionDigits`, then calls `.charAt` on it
expecting a string, so `roundToStepSize(5 as unknown as string, 0.01)` now throws
`TypeError: truncatedValue.charAt is not a function` where it used to throw
`TypeError: input.split is not a function`. Both are throws, just with different
messages, on both branches.

TypeScript already forbids all of these calls, so this only matters to an untyped
JS caller relying on the throw.

### 4. A negative or non-integer `maxFractionDigits` no longer corrupts the input

`capStringFractionDigits` fed `cfg.maxFractionDigits` straight into
`String.prototype.slice` without checking it first: `slice(0, NaN)` empties the
fraction, and `slice(0, -1)` drops the last character of the fraction instead of
capping it. It now returns the input unchanged whenever `maxFractionDigits` is not a
non-negative integer (`NaN`, negative, or non-integer).

`Infinity` is not part of what this fixes: `fraction.length <= Infinity` was always
true, so an infinite `maxFractionDigits` already passed the input through unchanged
before this guard existed.

This reaches `truncateInputToPrecision` through `marketPrecisionExp.toNumber()`: a
negative exponent used to cut into the integer part instead of leaving the value
alone, and a non-integer one used to slice at a fractional string index.

| input | precisionExp | old | new |
| --- | --- | --- | --- |
| `1234.5678` | `-1` | `1234` | `1234.5678` |
| `1234.5678` | `NaN` | `1234.5678` | `1234.5678` |
| `1234.5678` | `2.5` | `1234.56` | `1234.5678` |

No live market config produces a negative, `NaN` or non-integer precision exponent, so
this is a hardening fix, not a reachable behaviour change today.

## Verification

```
bun run build         clean (tsc, no output)
bun run test          646 passing
bun run circular-deps No circular dependency found!
oxlint .              exit 0, no findings
oxfmt --check         All matched files use the correct format.
```

`git diff origin/master...HEAD --stat`:

```
 common-ts/src/format/market.ts                     |   2 +
 common-ts/src/utils/math/precision.ts              |  62 ++-
 common-ts/tests/format/market.test.ts              |  29 ++
 common-ts/tests/utils/precisionDelegation.test.ts  | 442 ++++++++++++++++++++
 4 files changed, 521 insertions(+), 14 deletions(-)
```

## Review findings fixed

- `capStringFractionDigits` no longer corrupts the input when `maxFractionDigits`
  is not a non-negative integer; it returns the input unchanged instead of feeding
  `NaN` or a negative number into `String.prototype.slice`.
- The `capToFractionDigits` adapter in `precision.ts` no longer hardcodes the `'.'`
  separator and a length of `1`; it reads `DECIMAL_SEPARATOR` from the format
  layer's locale module.
- Trimmed the `capToFractionDigits` and `roundToStepSize` JSDoc comments down to a
  sentence or two each, and corrected a comment that said the old exponential-step
  bug "reported zero decimals": that's only true for `1e-7` / `1e-9`; a step like
  `2.5e-7` counted the four digits of the exponential string, not zero.
- Added regression tests pinning the `maxFractionDigits` guard in
  `market.test.ts`, and extended the `truncateInputToPrecision` characterization
  corpus with a negative and a `NaN` precision exponent, plus a direct pin that
  `roundToStepSize` / `roundToStepSizeIfLargeEnough` still throw (with a different
  message) on non-string input while `truncateInputToPrecision` does not.
- Made category 3 above precise: it is only `truncateInputToPrecision` that stops
  throwing on non-string input; the other two deprecated helpers still throw.

## Review findings fixed (round 2)

- `capToFractionDigits` no longer relies on the `capped === input` identity check
  to catch non-string input: `NaN` never equals itself, so a `NaN` value fell
  through the check and threw on `input.lastIndexOf`. It now type-checks the input
  directly, the same way `capStringFractionDigits` does, and the identity check is
  left in only as an optimisation for a genuinely unchanged string.
- The `'0'` head that the core injects ahead of a leading separator is now dropped
  with a plain `slice(1)` and a comment saying so, instead of `DECIMAL_SEPARATOR.length`,
  which happened to be `1` but was tracking the separator's length, not the injected
  character.
- `roundToStepSize`'s trailing-separator check now compares against
  `DECIMAL_SEPARATOR` instead of a hardcoded `'.'`.
- Extended the corpus with a long-first-fraction multi-separator shape
  (`'1.23456.7'`, `'9.99999.9'`) where the parsed value moves upward instead of
  down, a non-integer `2.5` exponent case for `truncateInputToPrecision`, and
  negative / `NaN` / infinite steps, which turned out to mirror an existing
  digit-count group rather than open a new one.
- Pinned that a `NaN` input to `truncateInputToPrecision` now returns `NaN`
  unchanged instead of throwing on `.split`, matching the guard fix above.
- Split the `Infinity` assertion in `market.test.ts` out of the `maxFractionDigits`
  regression test: it was already true before the guard existed, so it isn't one
  of the regressions the guard fixes.
- Corrected the call-site count below from "roughly 34" to the inventoried number.

## Squash merge note

This branch's commits carry distinct conventional messages, including
`fix(common-ts): reject an invalid maxFractionDigits in capStringFractionDigits`.
Keep that line in the squash commit body (not just folded into the top subject)
when merging, since changelog generation reads it from there.

## Do not merge until protocol-v2-mono #5304 is merged

The UI has 37 call sites of these three helpers, 17 of which can reach an order
payload, inventoried in protocol-v2-mono PR #5304. That PR is adding
characterization and interaction tests for them first, so the digit-count change
above is pinned from the caller side before it ships. Hold this one until that PR
is merged.
