### PR TITLE
test(common-ts): keep the BigNum fuzz sweep under the mocha timeout

### DIFF
--- a/common-ts/tests/format/bigNumFuzz.test.ts
+++ b/common-ts/tests/format/bigNumFuzz.test.ts
@@ -137,7 +137,8 @@ function sweep(
 	maxScale: number,
 	expectFired: string[]
 ) {
-	it(label, () => {
+	it(label, function () {
+		this.timeout(20000);
 		const rng = makeRng(seed);
 		const fired = new Set<string>();
 


### PR DESCRIPTION
CI run https://github.com/velocity-exchange/velocity-common/actions/runs/34101821445 failed `common-ts/tests/format/bigNumFuzz.test.ts` with a 2000ms mocha timeout on the wide sweep case, because that runner is slower than a local machine while the test passes locally in under 600ms.

Rather than thinning the 10000-iteration sample count (which is the sweep's intended coverage depth per its own docstring), this gives both sweeps an explicit `this.timeout(20000)` so they have headroom on a slow runner without losing coverage.

The 20 s budget is about 10x the point where CI failed (the runner is 3 to 4x slower than a laptop for this sweep); it was not tuned further. Every other test under `tests/format/**` finishes in under 30 ms, so no other case is near the default.
