### PR TITLE
refactor(common-ts): delegate the NumLib display members to the format layer

### DIFF
--- a/common-ts/src/format/presets.ts
+++ b/common-ts/src/format/presets.ts
@@ -1,9 +1,24 @@
 import { ENTIRE_POSITION } from './sentinels';
-import { FormatOptions, LegacyNumberType, SentinelRule } from './types';
+import {
+	DigitSpec,
+	FormatOptions,
+	LegacyNumberType,
+	SentinelRule,
+} from './types';
 
 const NON_POSITIVE_LEVERAGE: SentinelRule = {
 	matches: (v) => v.sign !== 1,
 	text: '1x',
+};
+
+const ZERO_PRICE: SentinelRule = {
+	matches: (v) => v.sign === 0,
+	text: '0.00',
+};
+
+const ZERO_AMOUNT: SentinelRule = {
+	matches: (v) => v.sign === 0,
+	text: '0',
 };
 
 /** Recursive, because every nested digits/abbreviate/sentinel object is shared. */
@@ -49,6 +64,13 @@ const usdHalfUp = freeze({
 		decimals: 2,
 		rounding: 'half-up' as const,
 	},
+});
+
+/** A trade price at full precision. Shared by the two price presets below. */
+const PRICE_DIGITS: DigitSpec = deepFreeze({
+	kind: 'significant' as const,
+	significant: 6,
+	rounding: 'half-up' as const,
 });
 
 export const PRESETS = Object.freeze({
@@ -135,6 +157,101 @@ export const PRESETS = Object.freeze({
 			significant: 6,
 			rounding: 'truncate' as const,
 		},
+	}),
+	/**
+	 * The same six figures rounded rather than truncated, capped at five
+	 * decimals so a sub-cent price stops where a trade price stops.
+	 * Ungrouped, for a value read back as text.
+	 */
+	tradePrecisionHalfUp: freeze({
+		digits: {
+			kind: 'significant' as const,
+			significant: 6,
+			rounding: 'half-up' as const,
+			maxDecimals: 5,
+		},
+		grouping: false,
+	}),
+	/** Six significant figures, grouped, with a zero price shown as 0.00. */
+	displayPrice: freeze({
+		digits: PRICE_DIGITS,
+		sentinels: [ZERO_PRICE],
+	}),
+	/** The same six figures as plain text: ungrouped, trailing zeros dropped. */
+	priceText: freeze({
+		digits: PRICE_DIGITS,
+		trimTrailingZeros: true,
+		grouping: false,
+	}),
+	/**
+	 * A base-asset amount: five significant figures, never more than four
+	 * decimals, and anything under 0.00001 rendered as a bound rather than as
+	 * digits nobody can act on.
+	 */
+	baseAmount: freeze({
+		digits: {
+			kind: 'significant' as const,
+			significant: 5,
+			rounding: 'half-up' as const,
+			maxDecimals: 4,
+		},
+		small: { mode: 'sentinel' as const, sentinelAt: '0.00001' },
+	}),
+	/**
+	 * A wallet balance shown against an earn product. Floored, so it never
+	 * offers more than the wallet holds, and ungrouped for a deposit input.
+	 */
+	earnBalance: freeze({
+		digits: {
+			kind: 'decimals' as const,
+			decimals: 4,
+			rounding: 'floor' as const,
+		},
+		trimTrailingZeros: true,
+		grouping: false,
+	}),
+	/**
+	 * Two decimals of an abbreviated mantissa, for balances, volumes and
+	 * totals. Below a cent it keeps two significant digits instead, and
+	 * anything unusable reads as a plain zero.
+	 */
+	millifiedAmount: freeze({
+		digits: {
+			kind: 'decimals' as const,
+			decimals: 2,
+			rounding: 'half-up' as const,
+		},
+		abbreviate: {
+			threshold: '1000',
+			digits: {
+				kind: 'decimals' as const,
+				decimals: 2,
+				rounding: 'half-up' as const,
+			},
+		},
+		small: {
+			mode: 'significant' as const,
+			minSignificant: 2,
+			maxLeadingZeros: 1,
+		},
+		sentinels: [ZERO_AMOUNT],
+		invalidText: '0',
+		nonFiniteText: { positive: '0', negative: '0' },
+	}),
+	/**
+	 * Exact digits, except at the two ends: a value with more than three
+	 * leading zeros takes the subscript form, and one with seven or more
+	 * integer digits abbreviates at six significant figures.
+	 */
+	specialValue: freeze({
+		digits: { kind: 'exact' as const },
+		small: { mode: 'subscript' as const },
+		abbreviate: {
+			minIntegerDigits: 7,
+			digits: PRICE_DIGITS,
+			trimTrailingZeros: true,
+		},
+		grouping: false,
 	}),
 	/**
 	 * Zero, a negative and unusable input all read as 1x, because there is no

--- a/common-ts/src/format/presets.ts
+++ b/common-ts/src/format/presets.ts
@@ -212,8 +212,9 @@ export const PRESETS = Object.freeze({
 	}),
 	/**
 	 * Two decimals of an abbreviated mantissa, for balances, volumes and
-	 * totals. Below a cent it keeps two significant digits instead, and
-	 * anything unusable reads as a plain zero.
+	 * totals. Below a cent it keeps two significant digits instead, an
+	 * unreadable or non-finite value reads as a plain zero, and a missing one
+	 * takes the fallback.
 	 */
 	millifiedAmount: freeze({
 		digits: {

--- a/common-ts/src/utils/NumLib.ts
+++ b/common-ts/src/utils/NumLib.ts
@@ -4,6 +4,18 @@ import {
 	AMM_RESERVE_PRECISION,
 	BigNum,
 } from '@velocity-exchange/sdk';
+import {
+	FormatOptions,
+	PRESETS,
+	formatText,
+	formatValue,
+} from '../format/index';
+
+/** parseFloat needs the digits ungrouped, and an infinity it can read back. */
+const NUMERIC_TEXT: FormatOptions = {
+	grouping: false,
+	nonFiniteText: { positive: 'Infinity', negative: '-Infinity' },
+};
 
 /**
  * Utilities to convert numbers and BigNumbers (BN) to different formats for the UI.
@@ -11,6 +23,10 @@ import {
 export class NumLib {
 	private static locale = 'en';
 
+	/**
+	 * @deprecated The format layer renders en-US only, so this no longer moves
+	 * any separator the display members print.
+	 */
 	static setLocale = (locale: string) => {
 		this.locale = locale;
 	};
@@ -50,56 +66,31 @@ export class NumLib {
 	static formatNum = {
 		/**
 		 * Converts a number to a precision suitable to trade with
-		 * @param num
-		 * @returns
+		 *
+		 * @deprecated Use `formatText(num, PRESETS.priceText)` from
+		 * '@velocity-exchange/common/format'.
 		 */
-		toTradePrecision: (num: number) => {
-			return parseFloat(num.toPrecision(6));
-		},
-		toTradePrecisionString: (num: number, toLocaleString?: boolean) => {
-			if (num === 0)
-				return Number(0).toLocaleString(this.locale, {
-					minimumSignificantDigits: 6,
-					maximumSignificantDigits: 6,
-				});
-
-			// slice numbers which have leading 0s so that numbers are only 6 digits long.
-			//// trimAmount will be 1 for 0.1 -> 0.999, 2 for 0.01 -> 0.0999, etc.
-			//// Handle num = 0 edge case .. (log10(0) = infinity)
-			const trimAmount = Math.abs(
-				num >= 1 || num == 0
-					? 0
-					: Math.min(0, Math.floor(Math.log10(Math.abs(num))))
-			);
-
-			// max sigFigs = 6, min = 1
-			const sigFigs = Math.max(Math.min(6 - trimAmount, 6), 1);
-
-			const tradePrecisionString = num.toPrecision(sigFigs);
-
-			if (toLocaleString)
-				return NumLib.formatNum
-					.toTradePrecision(num)
-					.toLocaleString(this.locale, {
-						minimumSignificantDigits: sigFigs,
-						maximumSignificantDigits: sigFigs,
-					});
-
-			return tradePrecisionString;
-		},
+		toTradePrecision: (num: number) =>
+			parseFloat(formatText(num, { ...PRESETS.priceText, ...NUMERIC_TEXT })),
 		/**
-		 * Formats a notional dollar value for UI. Goes to max. 2 decimals (accurate to 1 cent)
-		 * @param num
-		 * @returns
+		 * @deprecated Use `formatText(num, PRESETS.tradePrecisionHalfUp)` from
+		 * '@velocity-exchange/common/format'.
 		 */
-		toNotionalDisplay: (num: number) => {
-			return `${num < 0 ? `-` : ``}$${(
-				Math.round(Math.abs(num) * 100) / 100
-			).toLocaleString(this.locale, {
-				maximumFractionDigits: 2,
-				minimumFractionDigits: 2,
-			})}`;
-		},
+		toTradePrecisionString: (num: number, toLocaleString?: boolean) =>
+			formatText(
+				num,
+				toLocaleString
+					? { ...PRESETS.tradePrecisionHalfUp, grouping: true }
+					: PRESETS.tradePrecisionHalfUp
+			),
+		/**
+		 * Formats a notional dollar value for UI. Goes to max. 2 decimals (accurate to 1 cent).
+		 * Rounds the cent, where `BigNum.toNotional` truncates it.
+		 *
+		 * @deprecated Use `formatText(num, PRESETS.usdHalfUp)` from
+		 * '@velocity-exchange/common/format'.
+		 */
+		toNotionalDisplay: (num: number) => formatText(num, PRESETS.usdHalfUp),
 		/**
 		 * Formats a notional dollar value. Goes to max. 2 decimals (accurate to 1 cent)
 		 * @param num
@@ -113,37 +104,35 @@ export class NumLib {
 		 * @param baseAmount
 		 * @param assetPrice in dollars
 		 * @param skipLocaleFormatting Format using toFixed rather than localeString, which can't be parsed with regular number parsing
-		 * @returns
+		 *
+		 * @deprecated Use `formatText(amount, PRESETS.baseAmount)` from
+		 * '@velocity-exchange/common/format'.
 		 */
 		toBaseDisplay: (
 			baseAmount: number,
 			_assetPrice?: number,
 			_skipLocaleFormatting = false,
 			customSigFigs = 5
-		): string => {
-			if (baseAmount < 1) {
-				if (baseAmount === 0) return '0.0000';
-
-				if (baseAmount < 0.00001) {
-					return '<0.00001';
-				}
-
-				return baseAmount.toFixed(4);
-			}
-			if (_skipLocaleFormatting) {
-				return baseAmount.toFixed(
-					Math.min(
-						Math.max(0, Math.floor(Math.log10((_assetPrice ?? 0) + 1))) + 2,
-						6
-					)
-				);
-			}
-
-			return baseAmount.toLocaleString(this.locale, {
-				minimumSignificantDigits: customSigFigs,
-				maximumSignificantDigits: customSigFigs,
-			});
-		},
+		): string =>
+			formatText(baseAmount, {
+				...PRESETS.baseAmount,
+				grouping: !_skipLocaleFormatting,
+				// The price-magnitude digits were only ever reached by an amount of
+				// one or more; below that the four-decimal shape stands.
+				digits:
+					_skipLocaleFormatting && Math.abs(baseAmount) >= 1
+						? {
+								kind: 'magnitude',
+								assetPrice: _assetPrice ?? 0,
+								rounding: 'half-up',
+							}
+						: {
+								kind: 'significant',
+								significant: customSigFigs,
+								rounding: 'half-up',
+								maxDecimals: 4,
+							},
+			}),
 		/**
 		 * This function prints the base amount of an asset with a number of decimals relative to the price of the asset, because for high priced assets we care about more accuracy in the base amount. Number of decimals corresponds to accuracy to ~ 1 cent
 		 * @param baseAmount
@@ -169,28 +158,28 @@ export class NumLib {
 			this.formatNum.toRawBn(quoteAmount, QUOTE_PRECISION),
 		/**
 		 * Formats to price in locale style
-		 * @param assetPrice
-		 * @returns
+		 *
+		 * @deprecated Use `formatText(price, PRESETS.displayPrice)` from
+		 * '@velocity-exchange/common/format'.
 		 */
-		toDisplayPrice: (assetPrice: number): string => {
-			if (assetPrice === undefined) return '';
-			if (assetPrice === 0) return assetPrice.toFixed(2);
-
-			return assetPrice.toLocaleString(this.locale, {
-				maximumSignificantDigits: 6,
-				minimumSignificantDigits: 6,
-			});
-		},
+		toDisplayPrice: (assetPrice: number): string =>
+			formatText(assetPrice, PRESETS.displayPrice),
 		/**
-		 * Formats a price
-		 * @param assetPrice
-		 * @returns
+		 * Rounds a price to six decimals. Converts only; it renders nothing.
+		 *
+		 * @deprecated Use `formatText(price, { digits: { kind: 'decimals',
+		 * decimals: 6, rounding: 'half-up' } })` from
+		 * '@velocity-exchange/common/format'.
 		 */
 		toPrice: (assetPrice: number): number => {
 			if (assetPrice === undefined) return 0;
-			if (assetPrice === 0) return parseFloat(assetPrice.toFixed(2));
 
-			return parseFloat(assetPrice.toFixed(6));
+			return parseFloat(
+				formatText(assetPrice, {
+					...NUMERIC_TEXT,
+					digits: { kind: 'decimals', decimals: 6, rounding: 'half-up' },
+				})
+			);
 		},
 		/**
 		 * Convert a number to a BN based on the required precision
@@ -224,28 +213,26 @@ export class NumLib {
 			return numericalAsBn;
 		},
 		/**
-		 * Truncates a number to a certain number of decimal places. This differs from .toFixed() in that it rounds down, whereas .toFixed() rounds to the nearest number.
-		 * @param num
-		 * @param decimalPlaces
-		 * @returns
+		 * Rounds a number down to a certain number of decimal places. This differs from .toFixed() in that it rounds down, whereas .toFixed() rounds to the nearest number. Rounds toward negative infinity, so a negative value grows.
+		 *
+		 * @deprecated Use `formatText(num, { digits: { kind: 'decimals',
+		 * decimals, rounding: 'floor' }, grouping: false })` from
+		 * '@velocity-exchange/common/format'.
 		 */
 		toDecimalPlaces: (
 			num: number,
 			decimalPlaces: number,
 			noPadding?: boolean
-		): string => {
-			const truncatedNum =
-				Math.floor(num * Math.pow(10, decimalPlaces)) /
-				Math.pow(10, decimalPlaces);
-			if (noPadding) {
-				return truncatedNum.toString();
-			}
-
-			const paddedNum = truncatedNum.toString();
-			const [integerPart, decimalPart = ''] = paddedNum.split('.');
-			const paddedDecimal = decimalPart.padEnd(decimalPlaces, '0');
-			return `${integerPart}.${paddedDecimal}`;
-		},
+		): string =>
+			formatText(num, {
+				digits: {
+					kind: 'decimals',
+					decimals: decimalPlaces,
+					rounding: 'floor',
+				},
+				grouping: false,
+				trimTrailingZeros: noPadding ?? false,
+			}),
 	};
 
 	static formatBn = {
@@ -259,9 +246,10 @@ export class NumLib {
 	};
 
 	/**
-	 * Outputs information and formatted string for UI based on its log10 value
-	 * @param value
-	 * @returns
+	 * Outputs information and formatted string for UI based on its magnitude
+	 *
+	 * @deprecated Use `formatValue(value, PRESETS.millifiedAmount)` from
+	 * '@velocity-exchange/common/format'.
 	 */
 	static millify = (
 		value: number
@@ -272,69 +260,31 @@ export class NumLib {
 		displayValue: number;
 		displayString: string;
 	} => {
-		if (!value)
-			return {
-				mantissa: 0,
-				symbol: '',
-				sigFigs: 1,
-				displayValue: 0,
-				displayString: '0',
-			};
-
-		const valueLog10 = Math.log10(value);
-
-		const metricAmount = Math.floor(valueLog10 / 3);
-
-		const sigFigs = Math.max(3 + (valueLog10 % 3), 1);
-
-		let symbol = '';
-		let mantissa = 1;
-
-		switch (metricAmount) {
-			case 1:
-				mantissa = 10 ** 3;
-				symbol = 'K';
-				break;
-			case 2:
-				mantissa = 10 ** 6;
-				symbol = 'M';
-				break;
-			case 3:
-				mantissa = 10 ** 9;
-				symbol = 'B';
-				break;
-			case 4:
-				mantissa = 10 ** 12;
-				symbol = 'T';
-				break;
-			case 0:
-			default:
-				mantissa = 1;
-				symbol = '';
-				break;
-		}
-
-		const displayValue = parseFloat(
-			(value / mantissa).toLocaleString(this.locale, {
-				maximumSignificantDigits: sigFigs,
-			})
-		);
-
-		const displayString = `${(value / mantissa).toLocaleString(this.locale, {
-			maximumSignificantDigits: sigFigs,
-		})}${symbol}`;
+		const formatted = formatValue(value, PRESETS.millifiedAmount);
+		const { parts } = formatted;
+		const rendered = `${parts.integer}${parts.fraction}`.replace(/,/g, '');
+		const numeric =
+			`${parts.sign}${parts.integer}${parts.decimalSeparator}${parts.fraction}`.replace(
+				/,/g,
+				''
+			);
 
 		return {
-			mantissa,
-			symbol,
-			sigFigs,
-			displayValue,
-			displayString,
+			mantissa: 10 ** (formatted.abbreviation?.exponent ?? 0),
+			symbol: formatted.abbreviation?.unit ?? '',
+			sigFigs: Math.max(rendered.replace(/^0+/, '').length, 1),
+			displayValue: Number(numeric),
+			displayString: formatted.text,
 		};
 	};
 
 	/**
-	 * Get the precision to use for an asset so that base asset amounts are on the same scale as USD cents
+	 * Get the precision to use for an asset so that base asset amounts are on the same scale as USD cents.
+	 *
+	 * This is a magnitude exponent read off the raw BN string, which counts the
+	 * minus sign as a digit, so a negative price gets one decimal more than the
+	 * same positive one. It is not the market precision `marketPrecisionFromSizes`
+	 * resolves, and must not be delegated to it.
 	 * @param assetPrice
 	 * @returns
 	 */

--- a/common-ts/src/utils/NumLib.ts
+++ b/common-ts/src/utils/NumLib.ts
@@ -21,15 +21,11 @@ const NUMERIC_TEXT: FormatOptions = {
  * Utilities to convert numbers and BigNumbers (BN) to different formats for the UI.
  */
 export class NumLib {
-	private static locale = 'en';
-
 	/**
-	 * @deprecated The format layer renders en-US only, so this no longer moves
-	 * any separator the display members print.
+	 * @deprecated The format layer renders en-US only, so a locale set here
+	 * moves nothing.
 	 */
-	static setLocale = (locale: string) => {
-		this.locale = locale;
-	};
+	static setLocale = (_locale: string) => {};
 
 	/**
 	 * Converts a Big Number to its regular number representation.
@@ -65,9 +61,10 @@ export class NumLib {
 
 	static formatNum = {
 		/**
-		 * Converts a number to a precision suitable to trade with
+		 * Converts a number to a precision suitable to trade with. Returns a
+		 * number, so the replacement parses the rendered text back.
 		 *
-		 * @deprecated Use `formatText(num, PRESETS.priceText)` from
+		 * @deprecated Use `parseFloat(formatText(num, PRESETS.priceText))` from
 		 * '@velocity-exchange/common/format'.
 		 */
 		toTradePrecision: (num: number) =>
@@ -113,26 +110,32 @@ export class NumLib {
 			_assetPrice?: number,
 			_skipLocaleFormatting = false,
 			customSigFigs = 5
-		): string =>
-			formatText(baseAmount, {
+		): string => {
+			const options: FormatOptions = {
 				...PRESETS.baseAmount,
 				grouping: !_skipLocaleFormatting,
-				// The price-magnitude digits were only ever reached by an amount of
-				// one or more; below that the four-decimal shape stands.
-				digits:
-					_skipLocaleFormatting && Math.abs(baseAmount) >= 1
-						? {
-								kind: 'magnitude',
-								assetPrice: _assetPrice ?? 0,
-								rounding: 'half-up',
-							}
-						: {
-								kind: 'significant',
-								significant: customSigFigs,
-								rounding: 'half-up',
-								maxDecimals: 4,
-							},
-			}),
+			};
+
+			// Below one the shape stops at four decimals whatever digits the caller
+			// asked for. The guard reads the magnitude, so a negative amount takes
+			// the same digits as the positive one, not the small-amount bound.
+			if (Math.abs(baseAmount) >= 1) {
+				options.digits = _skipLocaleFormatting
+					? {
+							kind: 'magnitude',
+							assetPrice: _assetPrice ?? 0,
+							rounding: 'half-up',
+						}
+					: {
+							kind: 'significant',
+							significant: customSigFigs,
+							rounding: 'half-up',
+							maxDecimals: 4,
+						};
+			}
+
+			return formatText(baseAmount, options);
+		},
 		/**
 		 * This function prints the base amount of an asset with a number of decimals relative to the price of the asset, because for high priced assets we care about more accuracy in the base amount. Number of decimals corresponds to accuracy to ~ 1 cent
 		 * @param baseAmount
@@ -216,8 +219,8 @@ export class NumLib {
 		 * Rounds a number down to a certain number of decimal places. This differs from .toFixed() in that it rounds down, whereas .toFixed() rounds to the nearest number. Rounds toward negative infinity, so a negative value grows.
 		 *
 		 * @deprecated Use `formatText(num, { digits: { kind: 'decimals',
-		 * decimals, rounding: 'floor' }, grouping: false })` from
-		 * '@velocity-exchange/common/format'.
+		 * decimals, rounding: 'floor' }, grouping: false, trimTrailingZeros:
+		 * noPadding })` from '@velocity-exchange/common/format'.
 		 */
 		toDecimalPlaces: (
 			num: number,
@@ -273,7 +276,8 @@ export class NumLib {
 			mantissa: 10 ** (formatted.abbreviation?.exponent ?? 0),
 			symbol: formatted.abbreviation?.unit ?? '',
 			sigFigs: Math.max(rendered.replace(/^0+/, '').length, 1),
-			displayValue: Number(numeric),
+			// A missing value renders the fallback, which is text rather than digits.
+			displayValue: formatted.status === 'ok' ? Number(numeric) : 0,
 			displayString: formatted.text,
 		};
 	};

--- a/common-ts/src/utils/millify.ts
+++ b/common-ts/src/utils/millify.ts
@@ -1,7 +1,4 @@
-/**
- * There is a "millify" npm library but it is multiple kilobytes and opens space
- * for security vulnerabilities. Easier to just roll our own as it's not complicated.
- */
+import { DigitSpec, formatText } from '../format/index';
 
 interface MillifyOptions {
 	precision?: number;
@@ -10,48 +7,40 @@ interface MillifyOptions {
 	trimEndingZeroes?: boolean;
 }
 
-const FINANCIAL_UNITS = ['', 'K', 'M', 'B', 'T', 'Q'];
-const SCIENTIFIC_UNITS = ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
-
+/**
+ * @deprecated Use `formatText` with an `abbreviate` spec from
+ * '@velocity-exchange/common/format'.
+ */
 export default function millify(
 	value: number,
 	options?: MillifyOptions
 ): string {
 	const precision = options?.precision ?? 6;
 	const trimEndingZeroes = options?.trimEndingZeroes ?? false;
+	const significant: DigitSpec = {
+		kind: 'significant',
+		significant: precision,
+		rounding: 'half-up',
+	};
 
-	if (isNaN(value)) return '0';
-
-	const isNegative = value < 0;
-	const absoluteValue = Math.abs(value);
-
-	const units =
-		(options?.notation ?? 'financial') === 'financial'
-			? FINANCIAL_UNITS
-			: SCIENTIFIC_UNITS;
-
-	if (absoluteValue < 1000) {
-		const formattedValue = absoluteValue.toPrecision(precision);
-		const trimmedValue = trimEndingZeroes
-			? parseFloat(formattedValue).toString()
-			: formattedValue;
-		return `${isNegative ? '-' : ''}${trimmedValue}`;
-	}
-
-	const unitIndex = Math.min(
-		Math.floor(Math.log10(absoluteValue) / 3),
-		units.length - 1
-	);
-
-	const scaledValue = absoluteValue / Math.pow(1000, unitIndex);
-	const valueWithDecimals =
-		options?.decimals !== undefined
-			? scaledValue.toFixed(options.decimals)
-			: scaledValue.toPrecision(precision);
-
-	const trimmedValue = trimEndingZeroes
-		? parseFloat(valueWithDecimals).toString()
-		: valueWithDecimals;
-
-	return `${isNegative ? '-' : ''}${trimmedValue}${units[unitIndex]}`;
+	return formatText(value, {
+		digits: significant,
+		grouping: false,
+		trimTrailingZeros: trimEndingZeroes,
+		abbreviate: {
+			threshold: '1000',
+			units: options?.notation === 'scientific' ? 'si' : 'financial',
+			digits:
+				options?.decimals === undefined
+					? significant
+					: {
+							kind: 'decimals',
+							decimals: options.decimals,
+							rounding: 'half-up',
+						},
+			trimTrailingZeros: trimEndingZeroes,
+		},
+		fallback: '0',
+		invalidText: '0',
+	});
 }

--- a/common-ts/src/utils/trading/size.ts
+++ b/common-ts/src/utils/trading/size.ts
@@ -10,6 +10,7 @@ import {
 	SpotMarketAccount,
 	ZERO,
 } from '@velocity-exchange/sdk';
+import { PRESETS, formatText } from '../../format/index';
 import { MarketId } from '../../types';
 
 const getMarketTickSize = (
@@ -120,15 +121,22 @@ export const getMaxLeverageOrderSize = (orderAmount: BigNum): BigNum => {
  * @param orderAmount - The BigNum order amount to format
  * @param formatFn - Optional custom format function, defaults to prettyPrint()
  * @returns Formatted string showing either "Entire Position" or the formatted amount
+ *
+ * @deprecated Use `formatText(amount, PRESETS.orderSize)` from
+ * '@velocity-exchange/common/format'.
  */
 export const formatOrderSize = (
 	orderAmount: BigNum,
 	formatFn?: (amount: BigNum) => string
 ): string => {
+	// The sentinel in PRESETS.orderSize matches the marker units exactly, where
+	// this check also catches an amount a step size moved off them.
 	if (isEntirePositionOrder(orderAmount)) {
 		return 'Entire Position';
 	}
-	return formatFn ? formatFn(orderAmount) : orderAmount.prettyPrint();
+	return formatFn
+		? formatFn(orderAmount)
+		: formatText(orderAmount, PRESETS.orderSize);
 };
 
 export {

--- a/common-ts/tests/format/tradingPresets.test.ts
+++ b/common-ts/tests/format/tradingPresets.test.ts
@@ -1,0 +1,155 @@
+import { expect } from 'chai';
+import { PRESETS, formatText, formatValue } from '../../src/format/index';
+
+/**
+ * The presets the trading surfaces render with. Each one is checked for the
+ * shape it declares and for what that shape produces, so a change to either
+ * has to be deliberate.
+ */
+describe('the trading display presets', () => {
+	it('are frozen all the way down', () => {
+		const nested: [string, unknown][] = [
+			['displayPrice.digits', PRESETS.displayPrice.digits],
+			['displayPrice.sentinels', PRESETS.displayPrice.sentinels],
+			['displayPrice.sentinels[0]', PRESETS.displayPrice.sentinels![0]],
+			['priceText.digits', PRESETS.priceText.digits],
+			['tradePrecisionHalfUp.digits', PRESETS.tradePrecisionHalfUp.digits],
+			['baseAmount.digits', PRESETS.baseAmount.digits],
+			['baseAmount.small', PRESETS.baseAmount.small],
+			['earnBalance.digits', PRESETS.earnBalance.digits],
+			['millifiedAmount.digits', PRESETS.millifiedAmount.digits],
+			['millifiedAmount.abbreviate', PRESETS.millifiedAmount.abbreviate],
+			['millifiedAmount.small', PRESETS.millifiedAmount.small],
+			['millifiedAmount.sentinels', PRESETS.millifiedAmount.sentinels],
+			['specialValue.abbreviate', PRESETS.specialValue.abbreviate],
+			['specialValue.small', PRESETS.specialValue.small],
+		];
+		for (const [name, value] of nested) {
+			expect(Object.isFrozen(value), name).to.equal(true);
+		}
+	});
+
+	it('declare the shapes the UI holds today', () => {
+		expect(PRESETS.displayPrice.digits).to.deep.equal({
+			kind: 'significant',
+			significant: 6,
+			rounding: 'half-up',
+		});
+		expect(PRESETS.priceText.digits).to.deep.equal(PRESETS.displayPrice.digits);
+		expect(PRESETS.priceText.trimTrailingZeros).to.equal(true);
+		expect(PRESETS.priceText.grouping).to.equal(false);
+		expect(PRESETS.tradePrecisionHalfUp.digits).to.deep.equal({
+			kind: 'significant',
+			significant: 6,
+			rounding: 'half-up',
+			maxDecimals: 5,
+		});
+		expect(PRESETS.baseAmount.digits).to.deep.equal({
+			kind: 'significant',
+			significant: 5,
+			rounding: 'half-up',
+			maxDecimals: 4,
+		});
+		expect(PRESETS.baseAmount.small).to.deep.equal({
+			mode: 'sentinel',
+			sentinelAt: '0.00001',
+		});
+		expect(PRESETS.earnBalance.digits).to.deep.equal({
+			kind: 'decimals',
+			decimals: 4,
+			rounding: 'floor',
+		});
+		expect(PRESETS.millifiedAmount.abbreviate).to.deep.equal({
+			threshold: '1000',
+			digits: { kind: 'decimals', decimals: 2, rounding: 'half-up' },
+		});
+		expect(PRESETS.specialValue.abbreviate).to.deep.equal({
+			minIntegerDigits: 7,
+			digits: { kind: 'significant', significant: 6, rounding: 'half-up' },
+			trimTrailingZeros: true,
+		});
+		expect(PRESETS.specialValue.small).to.deep.equal({ mode: 'subscript' });
+	});
+
+	it('displayPrice keeps six figures, grouped, with 0.00 for a zero price', () => {
+		expect(formatText('1234.5678', PRESETS.displayPrice)).to.equal('1,234.57');
+		expect(formatText('1234567', PRESETS.displayPrice)).to.equal('1,234,570');
+		expect(formatText('0.000012345', PRESETS.displayPrice)).to.equal(
+			'0.000012345'
+		);
+		expect(formatText('0', PRESETS.displayPrice)).to.equal('0.00');
+		expect(formatValue('0', PRESETS.displayPrice).isSentinel).to.equal(true);
+		expect(formatText('-1234.5678', PRESETS.displayPrice)).to.equal(
+			'-1,234.57'
+		);
+	});
+
+	it('priceText drops the grouping and the trailing zeros', () => {
+		expect(formatText('1234.5678', PRESETS.priceText)).to.equal('1234.57');
+		expect(formatText('1234.50000', PRESETS.priceText)).to.equal('1234.5');
+		expect(formatText('0', PRESETS.priceText)).to.equal('0');
+	});
+
+	it('tradePrecisionHalfUp rounds six figures and stops at five decimals', () => {
+		expect(formatText('1.23456789', PRESETS.tradePrecisionHalfUp)).to.equal(
+			'1.23457'
+		);
+		expect(formatText('0.000012345', PRESETS.tradePrecisionHalfUp)).to.equal(
+			'0.00001'
+		);
+		expect(formatText('1234567', PRESETS.tradePrecisionHalfUp)).to.equal(
+			'1234570'
+		);
+		expect(formatText('0', PRESETS.tradePrecisionHalfUp)).to.equal('0.00000');
+	});
+
+	it('baseAmount holds five figures, four decimals and a small-amount bound', () => {
+		expect(formatText('1.23456789', PRESETS.baseAmount)).to.equal('1.2346');
+		expect(formatText('1234567', PRESETS.baseAmount)).to.equal('1,234,600');
+		expect(formatText('0.00001', PRESETS.baseAmount)).to.equal('0.0000');
+		expect(formatText('0.0000049', PRESETS.baseAmount)).to.equal('<0.00001');
+		expect(formatText('-0.0000049', PRESETS.baseAmount)).to.equal('>-0.00001');
+		expect(formatValue('0.0000049', PRESETS.baseAmount).usedSmallForm).to.equal(
+			true
+		);
+	});
+
+	it('earnBalance floors four decimals and trims what is left', () => {
+		expect(formatText('12.99999', PRESETS.earnBalance)).to.equal('12.9999');
+		expect(formatText('12.5000', PRESETS.earnBalance)).to.equal('12.5');
+		expect(formatText('1234567.89', PRESETS.earnBalance)).to.equal(
+			'1234567.89'
+		);
+		expect(formatText('0.00001', PRESETS.earnBalance)).to.equal('0');
+	});
+
+	it('millifiedAmount abbreviates past a thousand at two decimals', () => {
+		expect(formatText('1234', PRESETS.millifiedAmount)).to.equal('1.23K');
+		expect(formatText('999999.5', PRESETS.millifiedAmount)).to.equal('1.00M');
+		expect(formatText('1000000000', PRESETS.millifiedAmount)).to.equal('1.00B');
+		expect(formatText('999.994', PRESETS.millifiedAmount)).to.equal('999.99');
+		expect(formatText('0.00456', PRESETS.millifiedAmount)).to.equal('0.0045');
+		expect(formatText('0', PRESETS.millifiedAmount)).to.equal('0');
+		expect(formatText(NaN, PRESETS.millifiedAmount)).to.equal('0');
+		expect(formatText(Infinity, PRESETS.millifiedAmount)).to.equal('0');
+	});
+
+	it('specialValue takes a subscript below and an abbreviation above', () => {
+		expect(formatText('0.0000012345', PRESETS.specialValue)).to.equal(
+			'0.0₅12345'
+		);
+		expect(formatText('1234567', PRESETS.specialValue)).to.equal('1.23457M');
+		expect(formatText('12345678', PRESETS.specialValue)).to.equal('12.3457M');
+		const untouched = formatValue('1.5', PRESETS.specialValue);
+		expect(untouched.usedSmallForm).to.equal(false);
+		expect(untouched.wasAbbreviated).to.equal(false);
+		expect(untouched.text).to.equal('1.5');
+	});
+
+	it('a seven-digit negative reads its digits from the magnitude', () => {
+		expect(
+			formatValue('-1234567', PRESETS.specialValue).wasAbbreviated
+		).to.equal(true);
+		expect(formatText('-1234567', PRESETS.specialValue)).to.equal('-1.23457M');
+	});
+});

--- a/common-ts/tests/utils/numLibDelegation.test.ts
+++ b/common-ts/tests/utils/numLibDelegation.test.ts
@@ -23,6 +23,56 @@ import { CorpusCase, Divergence, runCorpus } from '../format/divergence';
 
 const LOCALE = 'en';
 
+// The behaviours the delegates change, named once and pointed at from every
+// case that shows one.
+const NO_PADDING_BELOW_ONE =
+	'a value below one keeps the digits it has, where a significant count used to pad it out';
+const NON_FINITE_TEXT =
+	'a non-finite or unreadable value renders as a symbol, not as the word NaN or Infinity';
+const NULLISH_DASH =
+	'a nullish input renders the fallback, where the old code threw or coerced it to zero';
+const NULLISH_NAN = 'a nullish input returns NaN instead of throwing';
+const EXACT_TIE =
+	'an exact decimal tie rounds up, where the double sat just below the tie';
+const EXACT_DIGITS =
+	'the digits come from the exact decimal, not from a double that cannot hold them';
+const EXACT_FLOOR =
+	'the floor is exact, where multiplying by a power of ten had already crossed the boundary';
+const NO_EXPONENT_FORM =
+	'the whole number is rendered, where toPrecision and toString switch to exponential';
+const DIGITS_AFTER_ROUNDING =
+	'the digit count follows the rounded value, so a carry past one keeps six figures';
+const SMALL_DIGIT_CREDIT =
+	'below 1e-5 the digit count no longer grows by one per leading zero';
+const NEGATIVES_KEEP_DIGITS =
+	'a negative amount keeps its digits, where a guard without an abs() sent all of them to the small-amount bound';
+const ZERO_FOLLOWS_SIG_FIGS =
+	'a zero renders one decimal fewer than the significant count asks for, instead of a flat four';
+const PRICE_MAGNITUDE =
+	'the decimals come from the price itself, not from the price plus one, so a price just below a power of ten no longer buys one';
+const PRICE_MAGNITUDE_MISSING =
+	'a missing or zero price takes six decimals, agreeing with toBase, where the price-plus-one heuristic gave two';
+const SIG_FIGS_DECIMAL_CAP =
+	'a significant count above five is still capped at four decimals';
+const TRAILING_SEPARATOR =
+	'at zero decimal places nothing dangles after the separator';
+const INVALID_PLACES =
+	'a negative or non-integer decimalPlaces throws instead of returning float noise';
+const MILLIFY_SIG_FIGS =
+	'sigFigs counts the digits actually rendered, where it used to be a fractional log';
+const MILLIFY_MANTISSA_ZERO =
+	'an unusable value reports a mantissa of one, the identity, rather than zero';
+const MILLIFY_TWO_DECIMALS = 'the mantissa always carries two decimals';
+const MILLIFY_NEGATIVES =
+	'a negative value renders, where the log of a negative left a NaN digit count that threw';
+const MILLIFY_NON_FINITE =
+	'a non-finite value renders zero, where the NaN digit count threw';
+const MILLIFY_UNIT_REDERIVED =
+	'the unit is re-derived after rounding, so 999,999.5 reads 1.00M rather than 1,000K';
+const MILLIFY_LARGE_UNITS = 'the units continue past T';
+const MILLIFY_SMALL_FORM =
+	'a value under a cent keeps two significant digits instead of one';
+
 const legacyToTradePrecision = (num: number) => parseFloat(num.toPrecision(6));
 
 const legacyToTradePrecisionString = (
@@ -335,7 +385,18 @@ describe('NumLib.formatNum.toTradePrecision', () => {
 		next: () => String(NumLib.formatNum.toTradePrecision(value)),
 	}));
 
-	const divergences: Record<string, Divergence> = {};
+	const divergences: Record<string, Divergence> = {
+		undefined: {
+			behaviour: NULLISH_NAN,
+			old: "THROWS: Cannot read properties of undefined (reading 'toPrecision')",
+			next: 'NaN',
+		},
+		null: {
+			behaviour: NULLISH_NAN,
+			old: "THROWS: Cannot read properties of null (reading 'toPrecision')",
+			next: 'NaN',
+		},
+	};
 
 	it('agrees with the pre-delegation implementation', () => {
 		runCorpus(cases, divergences);
@@ -359,7 +420,248 @@ describe('NumLib.formatNum.toTradePrecisionString', () => {
 		}
 	}
 
-	const divergences: Record<string, Divergence> = {};
+	const divergences: Record<string, Divergence> = {
+		'0.005': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.00500',
+			next: '0.005',
+		},
+		'0.005 localised': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.00500',
+			next: '0.005',
+		},
+		'-0.005': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '-0.00500',
+			next: '-0.005',
+		},
+		'-0.005 localised': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '-0.00500',
+			next: '-0.005',
+		},
+		'0.05': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.05000',
+			next: '0.05',
+		},
+		'0.05 localised': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.05000',
+			next: '0.05',
+		},
+		'0.285': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.28500',
+			next: '0.285',
+		},
+		'0.285 localised': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.28500',
+			next: '0.285',
+		},
+		'0.2849': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.28490',
+			next: '0.2849',
+		},
+		'0.2849 localised': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.28490',
+			next: '0.2849',
+		},
+		'0.29': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.29000',
+			next: '0.29',
+		},
+		'0.29 localised': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.29000',
+			next: '0.29',
+		},
+		'-0.29': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '-0.29000',
+			next: '-0.29',
+		},
+		'-0.29 localised': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '-0.29000',
+			next: '-0.29',
+		},
+		'0.5': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.50000',
+			next: '0.5',
+		},
+		'0.5 localised': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.50000',
+			next: '0.5',
+		},
+		'-0.5': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '-0.50000',
+			next: '-0.5',
+		},
+		'-0.5 localised': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '-0.50000',
+			next: '-0.5',
+		},
+		'0.0000049': {
+			behaviour: SMALL_DIGIT_CREDIT,
+			old: '0.000005',
+			next: '0.00000',
+		},
+		'0.0000049 localised': {
+			behaviour: SMALL_DIGIT_CREDIT,
+			old: '0.000005',
+			next: '0.00000',
+		},
+		'-0.0000049': {
+			behaviour: SMALL_DIGIT_CREDIT,
+			old: '-0.000005',
+			next: '-0.00000',
+		},
+		'-0.0000049 localised': {
+			behaviour: SMALL_DIGIT_CREDIT,
+			old: '-0.000005',
+			next: '-0.00000',
+		},
+		'0.0000051': {
+			behaviour: SMALL_DIGIT_CREDIT,
+			old: '0.000005',
+			next: '0.00001',
+		},
+		'0.0000051 localised': {
+			behaviour: SMALL_DIGIT_CREDIT,
+			old: '0.000005',
+			next: '0.00001',
+		},
+		'1e-7': {
+			behaviour: SMALL_DIGIT_CREDIT,
+			old: '1e-7',
+			next: '0.00000',
+		},
+		'1e-7 localised': {
+			behaviour: SMALL_DIGIT_CREDIT,
+			old: '0.0000001',
+			next: '0.00000',
+		},
+		'0.999995': {
+			behaviour: EXACT_TIE,
+			old: '0.99999',
+			next: '1.00000',
+		},
+		'0.999995 localised': {
+			behaviour: DIGITS_AFTER_ROUNDING,
+			old: '1.0000',
+			next: '1.00000',
+		},
+		'0.9999995': {
+			behaviour: DIGITS_AFTER_ROUNDING,
+			old: '1.0000',
+			next: '1.00000',
+		},
+		'0.9999995 localised': {
+			behaviour: DIGITS_AFTER_ROUNDING,
+			old: '1.0000',
+			next: '1.00000',
+		},
+		'1e6': {
+			behaviour: NO_EXPONENT_FORM,
+			old: '1.00000e+6',
+			next: '1000000',
+		},
+		'999999.5': {
+			behaviour: NO_EXPONENT_FORM,
+			old: '1.00000e+6',
+			next: '1000000',
+		},
+		'-999999.5': {
+			behaviour: NO_EXPONENT_FORM,
+			old: '-1.00000e+6',
+			next: '-1000000',
+		},
+		'999999999': {
+			behaviour: NO_EXPONENT_FORM,
+			old: '1.00000e+9',
+			next: '1000000000',
+		},
+		'1e9': {
+			behaviour: NO_EXPONENT_FORM,
+			old: '1.00000e+9',
+			next: '1000000000',
+		},
+		'1e12': {
+			behaviour: NO_EXPONENT_FORM,
+			old: '1.00000e+12',
+			next: '1000000000000',
+		},
+		'1e15': {
+			behaviour: NO_EXPONENT_FORM,
+			old: '1.00000e+15',
+			next: '1000000000000000',
+		},
+		'1e21': {
+			behaviour: NO_EXPONENT_FORM,
+			old: '1.00000e+21',
+			next: '1000000000000000000000',
+		},
+		'2^53': {
+			behaviour: NO_EXPONENT_FORM,
+			old: '9.00720e+15',
+			next: '9007200000000000',
+		},
+		'-2^53': {
+			behaviour: NO_EXPONENT_FORM,
+			old: '-9.00720e+15',
+			next: '-9007200000000000',
+		},
+		NaN: {
+			behaviour: NON_FINITE_TEXT,
+			old: 'NaN',
+			next: '?',
+		},
+		'NaN localised': {
+			behaviour: NON_FINITE_TEXT,
+			old: 'THROWS: minimumSignificantDigits value is out of range.',
+			next: '?',
+		},
+		Infinity: {
+			behaviour: NON_FINITE_TEXT,
+			old: 'Infinity',
+			next: '∞',
+		},
+		'-Infinity': {
+			behaviour: NON_FINITE_TEXT,
+			old: '-Infinity',
+			next: '-∞',
+		},
+		undefined: {
+			behaviour: NULLISH_DASH,
+			old: "THROWS: Cannot read properties of undefined (reading 'toPrecision')",
+			next: '-',
+		},
+		'undefined localised': {
+			behaviour: NULLISH_DASH,
+			old: "THROWS: Cannot read properties of undefined (reading 'toPrecision')",
+			next: '-',
+		},
+		null: {
+			behaviour: NULLISH_DASH,
+			old: "THROWS: Cannot read properties of null (reading 'toPrecision')",
+			next: '-',
+		},
+		'null localised': {
+			behaviour: NULLISH_DASH,
+			old: "THROWS: Cannot read properties of null (reading 'toPrecision')",
+			next: '-',
+		},
+	};
 
 	it('agrees with the pre-delegation implementation', () => {
 		runCorpus(cases, divergences);
@@ -377,7 +679,48 @@ describe('NumLib.formatNum.toNotionalDisplay', () => {
 		next: () => NumLib.formatNum.toNotionalDisplay(value),
 	}));
 
-	const divergences: Record<string, Divergence> = {};
+	const divergences: Record<string, Divergence> = {
+		'0.285': {
+			behaviour: EXACT_TIE,
+			old: '$0.28',
+			next: '$0.29',
+		},
+		'1.005': {
+			behaviour: EXACT_TIE,
+			old: '$1.00',
+			next: '$1.01',
+		},
+		'1e21': {
+			behaviour: EXACT_DIGITS,
+			old: '$999,999,999,999,999,900,000.00',
+			next: '$1,000,000,000,000,000,000,000.00',
+		},
+		NaN: {
+			behaviour: NON_FINITE_TEXT,
+			old: '$NaN',
+			next: '?',
+		},
+		Infinity: {
+			behaviour: NON_FINITE_TEXT,
+			old: '$∞',
+			next: '∞',
+		},
+		'-Infinity': {
+			behaviour: NON_FINITE_TEXT,
+			old: '-$∞',
+			next: '-∞',
+		},
+		undefined: {
+			behaviour: NULLISH_DASH,
+			old: '$NaN',
+			next: '-',
+		},
+		null: {
+			behaviour: NULLISH_DASH,
+			old: '$0.00',
+			next: '-',
+		},
+	};
 
 	it('agrees with the pre-delegation implementation', () => {
 		runCorpus(cases, divergences);
@@ -421,7 +764,253 @@ describe('NumLib.formatNum.toBaseDisplay', () => {
 		}
 	}
 
-	const divergences: Record<string, Divergence> = {};
+	const divergences: Record<string, Divergence> = {
+		'0.005': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.0050',
+			next: '0.005',
+		},
+		'-0.005': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '-0.005',
+		},
+		'0.05': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.0500',
+			next: '0.05',
+		},
+		'0.285': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.2850',
+			next: '0.285',
+		},
+		'0.29': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.2900',
+			next: '0.29',
+		},
+		'-0.29': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '-0.29',
+		},
+		'0.5': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.5000',
+			next: '0.5',
+		},
+		'-0.5': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '-0.5',
+		},
+		'-0.0000049': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '>-0.00001',
+		},
+		'-1': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '-1.0000',
+		},
+		'-9999.995': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '-10,000',
+		},
+		'-999999.5': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '-1,000,000',
+		},
+		'-2^53': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '-9,007,200,000,000,000',
+		},
+		NaN: {
+			behaviour: NON_FINITE_TEXT,
+			old: 'NaN',
+			next: '?',
+		},
+		'-Infinity': {
+			behaviour: NON_FINITE_TEXT,
+			old: '<0.00001',
+			next: '-∞',
+		},
+		undefined: {
+			behaviour: NULLISH_DASH,
+			old: "THROWS: Cannot read properties of undefined (reading 'toLocaleString')",
+			next: '-',
+		},
+		null: {
+			behaviour: NULLISH_DASH,
+			old: '<0.00001',
+			next: '-',
+		},
+		'0 @3sf': {
+			behaviour: ZERO_FOLLOWS_SIG_FIGS,
+			old: '0.0000',
+			next: '0.00',
+		},
+		'0.5 raw no price': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.5000',
+			next: '0.5',
+		},
+		'0.5 raw price 0': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.5000',
+			next: '0.5',
+		},
+		'0.5 raw price 9': {
+			behaviour: PRICE_MAGNITUDE,
+			old: '0.5000',
+			next: '0.5',
+		},
+		'0.5 raw price 10': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.5000',
+			next: '0.5',
+		},
+		'0.5 raw price 1234.56': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.5000',
+			next: '0.5',
+		},
+		'0.5 @3sf': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.5000',
+			next: '0.5',
+		},
+		'0.5 @8sf': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.5000',
+			next: '0.5',
+		},
+		'-0.5 raw no price': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '-0.5',
+		},
+		'-0.5 raw price 0': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '-0.5',
+		},
+		'-0.5 raw price 9': {
+			behaviour: PRICE_MAGNITUDE,
+			old: '<0.00001',
+			next: '-0.5',
+		},
+		'-0.5 raw price 10': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '-0.5',
+		},
+		'-0.5 raw price 1234.56': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '-0.5',
+		},
+		'-0.5 @3sf': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '-0.5',
+		},
+		'-0.5 @8sf': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '-0.5',
+		},
+		'1.23456789 raw no price': {
+			behaviour: PRICE_MAGNITUDE_MISSING,
+			old: '1.23',
+			next: '1.234568',
+		},
+		'1.23456789 raw price 0': {
+			behaviour: PRICE_MAGNITUDE_MISSING,
+			old: '1.23',
+			next: '1.234568',
+		},
+		'1.23456789 raw price 9': {
+			behaviour: PRICE_MAGNITUDE,
+			old: '1.235',
+			next: '1.23',
+		},
+		'1.23456789 @8sf': {
+			behaviour: SIG_FIGS_DECIMAL_CAP,
+			old: '1.2345679',
+			next: '1.2346',
+		},
+		'12345.6789 raw no price': {
+			behaviour: PRICE_MAGNITUDE_MISSING,
+			old: '12345.68',
+			next: '12345.678900',
+		},
+		'12345.6789 raw price 0': {
+			behaviour: PRICE_MAGNITUDE_MISSING,
+			old: '12345.68',
+			next: '12345.678900',
+		},
+		'12345.6789 raw price 9': {
+			behaviour: PRICE_MAGNITUDE,
+			old: '12345.679',
+			next: '12345.68',
+		},
+		'1e6 raw no price': {
+			behaviour: PRICE_MAGNITUDE_MISSING,
+			old: '1000000.00',
+			next: '1000000.000000',
+		},
+		'1e6 raw price 0': {
+			behaviour: PRICE_MAGNITUDE_MISSING,
+			old: '1000000.00',
+			next: '1000000.000000',
+		},
+		'1e6 raw price 9': {
+			behaviour: PRICE_MAGNITUDE,
+			old: '1000000.000',
+			next: '1000000.00',
+		},
+		'NaN raw no price': {
+			behaviour: NON_FINITE_TEXT,
+			old: 'NaN',
+			next: '?',
+		},
+		'NaN raw price 0': {
+			behaviour: NON_FINITE_TEXT,
+			old: 'NaN',
+			next: '?',
+		},
+		'NaN raw price 9': {
+			behaviour: NON_FINITE_TEXT,
+			old: 'NaN',
+			next: '?',
+		},
+		'NaN raw price 10': {
+			behaviour: NON_FINITE_TEXT,
+			old: 'NaN',
+			next: '?',
+		},
+		'NaN raw price 1234.56': {
+			behaviour: NON_FINITE_TEXT,
+			old: 'NaN',
+			next: '?',
+		},
+		'NaN @3sf': {
+			behaviour: NON_FINITE_TEXT,
+			old: 'NaN',
+			next: '?',
+		},
+		'NaN @8sf': {
+			behaviour: NON_FINITE_TEXT,
+			old: 'NaN',
+			next: '?',
+		},
+	};
 
 	it('agrees with the pre-delegation implementation', () => {
 		runCorpus(cases, divergences);
@@ -439,7 +1028,98 @@ describe('NumLib.formatNum.toDisplayPrice', () => {
 		next: () => NumLib.formatNum.toDisplayPrice(value),
 	}));
 
-	const divergences: Record<string, Divergence> = {};
+	const divergences: Record<string, Divergence> = {
+		'0.005': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.00500000',
+			next: '0.005',
+		},
+		'-0.005': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '-0.00500000',
+			next: '-0.005',
+		},
+		'0.05': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.0500000',
+			next: '0.05',
+		},
+		'0.285': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.285000',
+			next: '0.285',
+		},
+		'0.2849': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.284900',
+			next: '0.2849',
+		},
+		'0.29': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.290000',
+			next: '0.29',
+		},
+		'-0.29': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '-0.290000',
+			next: '-0.29',
+		},
+		'0.5': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.500000',
+			next: '0.5',
+		},
+		'-0.5': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '-0.500000',
+			next: '-0.5',
+		},
+		'0.0000049': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.00000490000',
+			next: '0.0000049',
+		},
+		'-0.0000049': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '-0.00000490000',
+			next: '-0.0000049',
+		},
+		'0.0000051': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.00000510000',
+			next: '0.0000051',
+		},
+		'0.00001': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.0000100000',
+			next: '0.00001',
+		},
+		'1e-7': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.000000100000',
+			next: '0.0000001',
+		},
+		'0.99999': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.999990',
+			next: '0.99999',
+		},
+		NaN: {
+			behaviour: NON_FINITE_TEXT,
+			old: 'NaN',
+			next: '?',
+		},
+		undefined: {
+			behaviour: NULLISH_DASH,
+			old: '',
+			next: '-',
+		},
+		null: {
+			behaviour: NULLISH_DASH,
+			old: "THROWS: Cannot read properties of null (reading 'toLocaleString')",
+			next: '-',
+		},
+	};
 
 	it('agrees with the pre-delegation implementation', () => {
 		runCorpus(cases, divergences);
@@ -457,7 +1137,13 @@ describe('NumLib.formatNum.toPrice', () => {
 		next: () => String(NumLib.formatNum.toPrice(value)),
 	}));
 
-	const divergences: Record<string, Divergence> = {};
+	const divergences: Record<string, Divergence> = {
+		null: {
+			behaviour: NULLISH_NAN,
+			old: "THROWS: Cannot read properties of null (reading 'toFixed')",
+			next: 'NaN',
+		},
+	};
 
 	it('agrees with the pre-delegation implementation', () => {
 		runCorpus(cases, divergences);
@@ -503,7 +1189,143 @@ describe('NumLib.formatNum.toDecimalPlaces', () => {
 		next: () => NumLib.formatNum.toDecimalPlaces(1.005, 3),
 	});
 
-	const divergences: Record<string, Divergence> = {};
+	const divergences: Record<string, Divergence> = {
+		'0.29 @2dp': {
+			behaviour: EXACT_FLOOR,
+			old: '0.28',
+			next: '0.29',
+		},
+		'0.29 @2dp unpadded': {
+			behaviour: EXACT_FLOOR,
+			old: '0.28',
+			next: '0.29',
+		},
+		'1e21 @2dp': {
+			behaviour: EXACT_DIGITS,
+			old: '999999999999999900000.00',
+			next: '1000000000000000000000.00',
+		},
+		'1e21 @2dp unpadded': {
+			behaviour: EXACT_DIGITS,
+			old: '999999999999999900000',
+			next: '1000000000000000000000',
+		},
+		'NaN @2dp': {
+			behaviour: NON_FINITE_TEXT,
+			old: 'NaN.00',
+			next: '?',
+		},
+		'NaN @2dp unpadded': {
+			behaviour: NON_FINITE_TEXT,
+			old: 'NaN',
+			next: '?',
+		},
+		'Infinity @2dp': {
+			behaviour: NON_FINITE_TEXT,
+			old: 'Infinity.00',
+			next: '∞',
+		},
+		'Infinity @2dp unpadded': {
+			behaviour: NON_FINITE_TEXT,
+			old: 'Infinity',
+			next: '∞',
+		},
+		'-Infinity @2dp': {
+			behaviour: NON_FINITE_TEXT,
+			old: '-Infinity.00',
+			next: '-∞',
+		},
+		'-Infinity @2dp unpadded': {
+			behaviour: NON_FINITE_TEXT,
+			old: '-Infinity',
+			next: '-∞',
+		},
+		'undefined @2dp': {
+			behaviour: NULLISH_DASH,
+			old: 'NaN.00',
+			next: '-',
+		},
+		'undefined @2dp unpadded': {
+			behaviour: NULLISH_DASH,
+			old: 'NaN',
+			next: '-',
+		},
+		'null @2dp': {
+			behaviour: NULLISH_DASH,
+			old: '0.00',
+			next: '-',
+		},
+		'null @2dp unpadded': {
+			behaviour: NULLISH_DASH,
+			old: '0',
+			next: '-',
+		},
+		'0 @0dp': {
+			behaviour: TRAILING_SEPARATOR,
+			old: '0.',
+			next: '0',
+		},
+		'0.5 @0dp': {
+			behaviour: TRAILING_SEPARATOR,
+			old: '0.',
+			next: '0',
+		},
+		'-0.5 @0dp': {
+			behaviour: TRAILING_SEPARATOR,
+			old: '-1.',
+			next: '-1',
+		},
+		'0.0000049 @0dp': {
+			behaviour: TRAILING_SEPARATOR,
+			old: '0.',
+			next: '0',
+		},
+		'1.23456789 @0dp': {
+			behaviour: TRAILING_SEPARATOR,
+			old: '1.',
+			next: '1',
+		},
+		'12345.6789 @0dp': {
+			behaviour: TRAILING_SEPARATOR,
+			old: '12345.',
+			next: '12345',
+		},
+		'1e6 @0dp': {
+			behaviour: TRAILING_SEPARATOR,
+			old: '1000000.',
+			next: '1000000',
+		},
+		'NaN @0dp': {
+			behaviour: NON_FINITE_TEXT,
+			old: 'NaN.',
+			next: '?',
+		},
+		'NaN @4dp': {
+			behaviour: NON_FINITE_TEXT,
+			old: 'NaN.0000',
+			next: '?',
+		},
+		'NaN @6dp': {
+			behaviour: NON_FINITE_TEXT,
+			old: 'NaN.000000',
+			next: '?',
+		},
+		'1.23456789 @-1dp': {
+			behaviour: INVALID_PLACES,
+			old: '0.',
+			next: 'THROWS: decimals must be a non-negative integer, got -1',
+		},
+		'1.23456789 @1.5dp': {
+			behaviour: INVALID_PLACES,
+			old: '1.2332882874656679',
+			next: 'THROWS: decimals must be a non-negative integer, got 1.5',
+		},
+		'1.005 @3dp': {
+			behaviour: EXACT_FLOOR,
+			old: '1.004',
+			next: '1.005',
+		},
+	};
 
 	it('agrees with the pre-delegation implementation', () => {
 		runCorpus(cases, divergences);
@@ -521,7 +1343,208 @@ describe('NumLib.millify', () => {
 		next: () => showMillifyResult(NumLib.millify(value)),
 	}));
 
-	const divergences: Record<string, Divergence> = {};
+	const divergences: Record<string, Divergence> = {
+		'0': {
+			behaviour: MILLIFY_MANTISSA_ZERO,
+			old: '0||1|0|0',
+			next: '1||1|0|0',
+		},
+		'-0': {
+			behaviour: MILLIFY_MANTISSA_ZERO,
+			old: '0||1|0|0',
+			next: '1||1|0|0',
+		},
+		'-0.005': {
+			behaviour: MILLIFY_NEGATIVES,
+			old: 'THROWS: maximumSignificantDigits value is out of range.',
+			next: '1||1|-0.005|-0.005',
+		},
+		'0.05': {
+			behaviour: MILLIFY_SIG_FIGS,
+			old: '1||1.6989700043360187|0.05|0.05',
+			next: '1||1|0.05|0.05',
+		},
+		'0.285': {
+			behaviour: MILLIFY_SIG_FIGS,
+			old: '1||2.45484486000851|0.29|0.29',
+			next: '1||2|0.29|0.29',
+		},
+		'0.2849': {
+			behaviour: MILLIFY_SIG_FIGS,
+			old: '1||2.454692449239477|0.28|0.28',
+			next: '1||2|0.28|0.28',
+		},
+		'0.29': {
+			behaviour: MILLIFY_SIG_FIGS,
+			old: '1||2.462397997898956|0.29|0.29',
+			next: '1||2|0.29|0.29',
+		},
+		'-0.29': {
+			behaviour: MILLIFY_NEGATIVES,
+			old: 'THROWS: maximumSignificantDigits value is out of range.',
+			next: '1||2|-0.29|-0.29',
+		},
+		'0.5': {
+			behaviour: MILLIFY_TWO_DECIMALS,
+			old: '1||2.6989700043360187|0.5|0.5',
+			next: '1||2|0.5|0.50',
+		},
+		'-0.5': {
+			behaviour: MILLIFY_NEGATIVES,
+			old: 'THROWS: maximumSignificantDigits value is out of range.',
+			next: '1||2|-0.5|-0.50',
+		},
+		'0.0000049': {
+			behaviour: MILLIFY_SMALL_FORM,
+			old: '1||1|0.000005|0.000005',
+			next: '1||2|0.0000049|0.0000049',
+		},
+		'-0.0000049': {
+			behaviour: MILLIFY_NEGATIVES,
+			old: 'THROWS: maximumSignificantDigits value is out of range.',
+			next: '1||2|-0.0000049|-0.0000049',
+		},
+		'0.0000051': {
+			behaviour: MILLIFY_SMALL_FORM,
+			old: '1||1|0.000005|0.000005',
+			next: '1||2|0.0000051|0.0000051',
+		},
+		'1e-7': {
+			behaviour: MILLIFY_SIG_FIGS,
+			old: '1||2|1e-7|0.0000001',
+			next: '1||1|1e-7|0.0000001',
+		},
+		'0.99999': {
+			behaviour: MILLIFY_TWO_DECIMALS,
+			old: '1||2.999995657033466|1|1',
+			next: '1||3|1|1.00',
+		},
+		'0.999995': {
+			behaviour: MILLIFY_TWO_DECIMALS,
+			old: '1||2.9999978285221616|1|1',
+			next: '1||3|1|1.00',
+		},
+		'0.9999995': {
+			behaviour: MILLIFY_TWO_DECIMALS,
+			old: '1||2.9999997828527047|1|1',
+			next: '1||3|1|1.00',
+		},
+		'1': {
+			behaviour: MILLIFY_TWO_DECIMALS,
+			old: '1||3|1|1',
+			next: '1||3|1|1.00',
+		},
+		'-1': {
+			behaviour: MILLIFY_NEGATIVES,
+			old: 'THROWS: maximumSignificantDigits value is out of range.',
+			next: '1||3|-1|-1.00',
+		},
+		'1.005': {
+			behaviour: MILLIFY_SIG_FIGS,
+			old: '1||3.002166061756508|1.01|1.01',
+			next: '1||3|1.01|1.01',
+		},
+		'1.23456789': {
+			behaviour: MILLIFY_SIG_FIGS,
+			old: '1||3.0915149771692705|1.23|1.23',
+			next: '1||3|1.23|1.23',
+		},
+		'9.999999': {
+			behaviour: MILLIFY_TWO_DECIMALS,
+			old: '1||3.9999999565705497|10|10',
+			next: '1||4|10|10.00',
+		},
+		'9999.995': {
+			behaviour: MILLIFY_TWO_DECIMALS,
+			old: '1000|K|3.9999997828527047|10|10K',
+			next: '1000|K|4|10|10.00K',
+		},
+		'-9999.995': {
+			behaviour: MILLIFY_NEGATIVES,
+			old: 'THROWS: maximumSignificantDigits value is out of range.',
+			next: '1000|K|4|-10|-10.00K',
+		},
+		'12345.6789': {
+			behaviour: MILLIFY_SIG_FIGS,
+			old: '1000|K|4.09151497716927|12.35|12.35K',
+			next: '1000|K|4|12.35|12.35K',
+		},
+		'1e6': {
+			behaviour: MILLIFY_TWO_DECIMALS,
+			old: '1000000|M|3|1|1M',
+			next: '1000000|M|3|1|1.00M',
+		},
+		'999999.5': {
+			behaviour: MILLIFY_UNIT_REDERIVED,
+			old: '1000|K|5.999999782852704|1|1,000K',
+			next: '1000000|M|3|1|1.00M',
+		},
+		'-999999.5': {
+			behaviour: MILLIFY_NEGATIVES,
+			old: 'THROWS: maximumSignificantDigits value is out of range.',
+			next: '1000000|M|3|-1|-1.00M',
+		},
+		'999999999': {
+			behaviour: MILLIFY_UNIT_REDERIVED,
+			old: '1000000|M|5.999999999565706|1|1,000M',
+			next: '1000000000|B|3|1|1.00B',
+		},
+		'1e9': {
+			behaviour: MILLIFY_TWO_DECIMALS,
+			old: '1000000000|B|3|1|1B',
+			next: '1000000000|B|3|1|1.00B',
+		},
+		'1e12': {
+			behaviour: MILLIFY_TWO_DECIMALS,
+			old: '1000000000000|T|3|1|1T',
+			next: '1000000000000|T|3|1|1.00T',
+		},
+		'1e15': {
+			behaviour: MILLIFY_LARGE_UNITS,
+			old: '1||3|1|1,000,000,000,000,000',
+			next: '1000000000000000|Q|3|1|1.00Q',
+		},
+		'1e21': {
+			behaviour: MILLIFY_LARGE_UNITS,
+			old: '1||3|1|1,000,000,000,000,000,000,000',
+			next: '1000000000000000|Q|9|1000000|1,000,000.00Q',
+		},
+		'2^53': {
+			behaviour: MILLIFY_LARGE_UNITS,
+			old: '1||3.954589770191003|9|9,010,000,000,000,000',
+			next: '1000000000000000|Q|3|9.01|9.01Q',
+		},
+		'-2^53': {
+			behaviour: MILLIFY_NEGATIVES,
+			old: 'THROWS: maximumSignificantDigits value is out of range.',
+			next: '1000000000000000|Q|3|-9.01|-9.01Q',
+		},
+		NaN: {
+			behaviour: MILLIFY_MANTISSA_ZERO,
+			old: '0||1|0|0',
+			next: '1||1|0|0',
+		},
+		Infinity: {
+			behaviour: MILLIFY_NON_FINITE,
+			old: 'THROWS: maximumSignificantDigits value is out of range.',
+			next: '1||1|0|0',
+		},
+		'-Infinity': {
+			behaviour: MILLIFY_NON_FINITE,
+			old: 'THROWS: maximumSignificantDigits value is out of range.',
+			next: '1||1|0|0',
+		},
+		undefined: {
+			behaviour: NULLISH_DASH,
+			old: '0||1|0|0',
+			next: '1||1|NaN|-',
+		},
+		null: {
+			behaviour: NULLISH_DASH,
+			old: '0||1|0|0',
+			next: '1||1|NaN|-',
+		},
+	};
 
 	it('agrees with the pre-delegation implementation', () => {
 		runCorpus(cases, divergences);
@@ -556,7 +1579,163 @@ describe('millify', () => {
 		}
 	}
 
-	const divergences: Record<string, Divergence> = {};
+	const divergences: Record<string, Divergence> = {
+		'0.005': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.00500000',
+			next: '0.005',
+		},
+		'-0.005': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '-0.00500000',
+			next: '-0.005',
+		},
+		'0.05': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.0500000',
+			next: '0.05',
+		},
+		'0.285': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.285000',
+			next: '0.285',
+		},
+		'0.2849': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.284900',
+			next: '0.2849',
+		},
+		'0.29': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.290000',
+			next: '0.29',
+		},
+		'-0.29': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '-0.290000',
+			next: '-0.29',
+		},
+		'0.5': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.500000',
+			next: '0.5',
+		},
+		'-0.5': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '-0.500000',
+			next: '-0.5',
+		},
+		'0.0000049': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.00000490000',
+			next: '0.0000049',
+		},
+		'-0.0000049': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '-0.00000490000',
+			next: '-0.0000049',
+		},
+		'0.0000051': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.00000510000',
+			next: '0.0000051',
+		},
+		'0.00001': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.0000100000',
+			next: '0.00001',
+		},
+		'1e-7': {
+			behaviour: NO_EXPONENT_FORM,
+			old: '1.00000e-7',
+			next: '0.0000001',
+		},
+		'0.99999': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.999990',
+			next: '0.99999',
+		},
+		'999999.5': {
+			behaviour: MILLIFY_UNIT_REDERIVED,
+			old: '1000.00K',
+			next: '1.00000M',
+		},
+		'-999999.5': {
+			behaviour: MILLIFY_UNIT_REDERIVED,
+			old: '-1000.00K',
+			next: '-1.00000M',
+		},
+		'999999999': {
+			behaviour: MILLIFY_UNIT_REDERIVED,
+			old: '1000.00M',
+			next: '1.00000B',
+		},
+		'1e21': {
+			behaviour: NO_EXPONENT_FORM,
+			old: '1.00000e+6Q',
+			next: '1000000Q',
+		},
+		Infinity: {
+			behaviour: NON_FINITE_TEXT,
+			old: 'InfinityQ',
+			next: '∞',
+		},
+		'-Infinity': {
+			behaviour: NON_FINITE_TEXT,
+			old: '-InfinityQ',
+			next: '-∞',
+		},
+		null: {
+			behaviour: NULLISH_DASH,
+			old: '0.00000',
+			next: '0',
+		},
+		'0.5 3sf': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.500',
+			next: '0.5',
+		},
+		'0.5 1dp': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.500000',
+			next: '0.5',
+		},
+		'0.5 scientific': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.500000',
+			next: '0.5',
+		},
+		'-0.5 3sf': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '-0.500',
+			next: '-0.5',
+		},
+		'-0.5 1dp': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '-0.500000',
+			next: '-0.5',
+		},
+		'-0.5 scientific': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '-0.500000',
+			next: '-0.5',
+		},
+		'0.0000049 3sf': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.00000490',
+			next: '0.0000049',
+		},
+		'0.0000049 1dp': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.00000490000',
+			next: '0.0000049',
+		},
+		'0.0000049 scientific': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.00000490000',
+			next: '0.0000049',
+		},
+	};
 
 	it('agrees with the pre-delegation implementation', () => {
 		runCorpus(cases, divergences);

--- a/common-ts/tests/utils/numLibDelegation.test.ts
+++ b/common-ts/tests/utils/numLibDelegation.test.ts
@@ -46,8 +46,6 @@ const SMALL_DIGIT_CREDIT =
 	'below 1e-5 the digit count no longer grows by one per leading zero';
 const NEGATIVES_KEEP_DIGITS =
 	'a negative amount keeps its digits, where a guard without an abs() sent all of them to the small-amount bound';
-const ZERO_FOLLOWS_SIG_FIGS =
-	'a zero renders one decimal fewer than the significant count asks for, instead of a flat four';
 const PRICE_MAGNITUDE =
 	'the decimals come from the price itself, not from the price plus one, so a price just below a power of ten no longer buys one';
 const PRICE_MAGNITUDE_MISSING =
@@ -75,6 +73,8 @@ const MILLIFY_SMALL_FORM =
 
 const legacyToTradePrecision = (num: number) => parseFloat(num.toPrecision(6));
 
+// The oracle spells the zero check `===` where the original had `==`; both
+// compare a number against zero, so the corpus is unaffected.
 const legacyToTradePrecisionString = (
 	num: number,
 	toLocaleString?: boolean
@@ -325,6 +325,8 @@ const VALUES: [string, number][] = [
 	['0.2849', 0.2849],
 	['0.29', 0.29],
 	['-0.29', -0.29],
+	['0.0567', 0.0567],
+	['0.12345', 0.12345],
 	['0.5', 0.5],
 	['-0.5', -0.5],
 	['0.0000049', 0.0000049],
@@ -353,6 +355,7 @@ const VALUES: [string, number][] = [
 	['1e21', 1e21],
 	['2^53', 2 ** 53],
 	['-2^53', -(2 ** 53)],
+	['MAX_VALUE', Number.MAX_VALUE],
 	['NaN', NaN],
 	['Infinity', Infinity],
 	['-Infinity', -Infinity],
@@ -363,12 +366,15 @@ const VALUES: [string, number][] = [
 /** The magnitudes worth re-running for every extra parameter. */
 const SWEEP_KEYS = [
 	'0',
+	'0.0567',
+	'0.12345',
 	'0.5',
 	'-0.5',
 	'0.0000049',
 	'1.23456789',
 	'12345.6789',
 	'1e6',
+	'-9999.995',
 	'NaN',
 ];
 
@@ -490,6 +496,16 @@ describe('NumLib.formatNum.toTradePrecisionString', () => {
 			behaviour: NO_PADDING_BELOW_ONE,
 			old: '-0.29000',
 			next: '-0.29',
+		},
+		'0.0567': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.05670',
+			next: '0.0567',
+		},
+		'0.0567 localised': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.05670',
+			next: '0.0567',
 		},
 		'0.5': {
 			behaviour: NO_PADDING_BELOW_ONE,
@@ -621,6 +637,11 @@ describe('NumLib.formatNum.toTradePrecisionString', () => {
 			old: '-9.00720e+15',
 			next: '-9007200000000000',
 		},
+		MAX_VALUE: {
+			behaviour: NO_EXPONENT_FORM,
+			old: '1.79769e+308',
+			next: '179769000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+		},
 		NaN: {
 			behaviour: NON_FINITE_TEXT,
 			old: 'NaN',
@@ -694,6 +715,11 @@ describe('NumLib.formatNum.toNotionalDisplay', () => {
 			behaviour: EXACT_DIGITS,
 			old: '$999,999,999,999,999,900,000.00',
 			next: '$1,000,000,000,000,000,000,000.00',
+		},
+		MAX_VALUE: {
+			behaviour: EXACT_DIGITS,
+			old: '$∞',
+			next: '$179,769,313,486,231,570,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000.00',
 		},
 		NaN: {
 			behaviour: NON_FINITE_TEXT,
@@ -850,11 +876,6 @@ describe('NumLib.formatNum.toBaseDisplay', () => {
 			old: '<0.00001',
 			next: '-',
 		},
-		'0 @3sf': {
-			behaviour: ZERO_FOLLOWS_SIG_FIGS,
-			old: '0.0000',
-			next: '0.00',
-		},
 		'0.5 raw no price': {
 			behaviour: NO_PADDING_BELOW_ONE,
 			old: '0.5000',
@@ -901,7 +922,7 @@ describe('NumLib.formatNum.toBaseDisplay', () => {
 			next: '-0.5',
 		},
 		'-0.5 raw price 9': {
-			behaviour: PRICE_MAGNITUDE,
+			behaviour: NEGATIVES_KEEP_DIGITS,
 			old: '<0.00001',
 			next: '-0.5',
 		},
@@ -944,6 +965,41 @@ describe('NumLib.formatNum.toBaseDisplay', () => {
 			behaviour: SIG_FIGS_DECIMAL_CAP,
 			old: '1.2345679',
 			next: '1.2346',
+		},
+		'-9999.995 raw no price': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '-9999.995000',
+		},
+		'-9999.995 raw price 0': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '-9999.995000',
+		},
+		'-9999.995 raw price 9': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '-10000.00',
+		},
+		'-9999.995 raw price 10': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '-9999.995',
+		},
+		'-9999.995 raw price 1234.56': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '-9999.99500',
+		},
+		'-9999.995 @3sf': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '-10,000',
+		},
+		'-9999.995 @8sf': {
+			behaviour: NEGATIVES_KEEP_DIGITS,
+			old: '<0.00001',
+			next: '-9,999.9950',
 		},
 		'12345.6789 raw no price': {
 			behaviour: PRICE_MAGNITUDE_MISSING,
@@ -1063,6 +1119,16 @@ describe('NumLib.formatNum.toDisplayPrice', () => {
 			behaviour: NO_PADDING_BELOW_ONE,
 			old: '-0.290000',
 			next: '-0.29',
+		},
+		'0.0567': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.0567000',
+			next: '0.0567',
+		},
+		'0.12345': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.123450',
+			next: '0.12345',
 		},
 		'0.5': {
 			behaviour: NO_PADDING_BELOW_ONE,
@@ -1210,6 +1276,16 @@ describe('NumLib.formatNum.toDecimalPlaces', () => {
 			old: '999999999999999900000',
 			next: '1000000000000000000000',
 		},
+		'MAX_VALUE @2dp': {
+			behaviour: EXACT_DIGITS,
+			old: 'Infinity.00',
+			next: '179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.00',
+		},
+		'MAX_VALUE @2dp unpadded': {
+			behaviour: EXACT_DIGITS,
+			old: 'Infinity',
+			next: '179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+		},
 		'NaN @2dp': {
 			behaviour: NON_FINITE_TEXT,
 			old: 'NaN.00',
@@ -1265,6 +1341,16 @@ describe('NumLib.formatNum.toDecimalPlaces', () => {
 			old: '0.',
 			next: '0',
 		},
+		'0.0567 @0dp': {
+			behaviour: TRAILING_SEPARATOR,
+			old: '0.',
+			next: '0',
+		},
+		'0.12345 @0dp': {
+			behaviour: TRAILING_SEPARATOR,
+			old: '0.',
+			next: '0',
+		},
 		'0.5 @0dp': {
 			behaviour: TRAILING_SEPARATOR,
 			old: '0.',
@@ -1284,6 +1370,16 @@ describe('NumLib.formatNum.toDecimalPlaces', () => {
 			behaviour: TRAILING_SEPARATOR,
 			old: '1.',
 			next: '1',
+		},
+		'-9999.995 @0dp': {
+			behaviour: TRAILING_SEPARATOR,
+			old: '-10000.',
+			next: '-10000',
+		},
+		'-9999.995 @4dp': {
+			behaviour: EXACT_FLOOR,
+			old: '-9999.9951',
+			next: '-9999.9950',
 		},
 		'12345.6789 @0dp': {
 			behaviour: TRAILING_SEPARATOR,
@@ -1383,6 +1479,16 @@ describe('NumLib.millify', () => {
 			behaviour: MILLIFY_NEGATIVES,
 			old: 'THROWS: maximumSignificantDigits value is out of range.',
 			next: '1||2|-0.29|-0.29',
+		},
+		'0.0567': {
+			behaviour: MILLIFY_SIG_FIGS,
+			old: '1||1.7535830588929067|0.06|0.06',
+			next: '1||1|0.06|0.06',
+		},
+		'0.12345': {
+			behaviour: MILLIFY_SIG_FIGS,
+			old: '1||2.091491094267951|0.12|0.12',
+			next: '1||2|0.12|0.12',
 		},
 		'0.5': {
 			behaviour: MILLIFY_TWO_DECIMALS,
@@ -1519,6 +1625,11 @@ describe('NumLib.millify', () => {
 			old: 'THROWS: maximumSignificantDigits value is out of range.',
 			next: '1000000000000000|Q|3|-9.01|-9.01Q',
 		},
+		MAX_VALUE: {
+			behaviour: MILLIFY_LARGE_UNITS,
+			old: '1||5.254715559916747|179|179,770,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000',
+			next: '1000000000000000|Q|296|1.7976931348623157e+293|179,769,313,486,231,570,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000.00Q',
+		},
 		NaN: {
 			behaviour: MILLIFY_MANTISSA_ZERO,
 			old: '0||1|0|0',
@@ -1537,12 +1648,12 @@ describe('NumLib.millify', () => {
 		undefined: {
 			behaviour: NULLISH_DASH,
 			old: '0||1|0|0',
-			next: '1||1|NaN|-',
+			next: '1||1|0|-',
 		},
 		null: {
 			behaviour: NULLISH_DASH,
 			old: '0||1|0|0',
-			next: '1||1|NaN|-',
+			next: '1||1|0|-',
 		},
 	};
 
@@ -1561,6 +1672,14 @@ describe('millify', () => {
 		legacy: () => legacyMillify(value),
 		next: () => millify(value),
 	}));
+
+	// The trimmed path handed parseFloat().toString() a value it renders in
+	// exponent form.
+	cases.push({
+		key: '1e-7 trimmed',
+		legacy: () => legacyMillify(1e-7, { trimEndingZeroes: true }),
+		next: () => millify(1e-7, { trimEndingZeroes: true }),
+	});
 
 	const OPTIONS: [string, MillifyOptions][] = [
 		['3sf', { precision: 3 }],
@@ -1614,6 +1733,16 @@ describe('millify', () => {
 			behaviour: NO_PADDING_BELOW_ONE,
 			old: '-0.290000',
 			next: '-0.29',
+		},
+		'0.0567': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.0567000',
+			next: '0.0567',
+		},
+		'0.12345': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.123450',
+			next: '0.12345',
 		},
 		'0.5': {
 			behaviour: NO_PADDING_BELOW_ONE,
@@ -1675,6 +1804,11 @@ describe('millify', () => {
 			old: '1.00000e+6Q',
 			next: '1000000Q',
 		},
+		MAX_VALUE: {
+			behaviour: NO_EXPONENT_FORM,
+			old: '1.79769e+293Q',
+			next: '179769000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000Q',
+		},
 		Infinity: {
 			behaviour: NON_FINITE_TEXT,
 			old: 'InfinityQ',
@@ -1689,6 +1823,31 @@ describe('millify', () => {
 			behaviour: NULLISH_DASH,
 			old: '0.00000',
 			next: '0',
+		},
+		'1e-7 trimmed': {
+			behaviour: NO_EXPONENT_FORM,
+			old: '1e-7',
+			next: '0.0000001',
+		},
+		'0.0567 1dp': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.0567000',
+			next: '0.0567',
+		},
+		'0.0567 scientific': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.0567000',
+			next: '0.0567',
+		},
+		'0.12345 1dp': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.123450',
+			next: '0.12345',
+		},
+		'0.12345 scientific': {
+			behaviour: NO_PADDING_BELOW_ONE,
+			old: '0.123450',
+			next: '0.12345',
 		},
 		'0.5 3sf': {
 			behaviour: NO_PADDING_BELOW_ONE,

--- a/common-ts/tests/utils/numLibDelegation.test.ts
+++ b/common-ts/tests/utils/numLibDelegation.test.ts
@@ -1,0 +1,606 @@
+import {
+	AMM_RESERVE_PRECISION_EXP,
+	BN,
+	BigNum,
+	MAX_LEVERAGE_ORDER_SIZE,
+} from '@velocity-exchange/sdk';
+import { NumLib } from '../../src/utils/NumLib';
+import millify from '../../src/utils/millify';
+import {
+	formatOrderSize,
+	isEntirePositionOrder,
+} from '../../src/utils/trading';
+import { CorpusCase, Divergence, runCorpus } from '../format/divergence';
+
+/**
+ * Characterization corpus for the NumLib display members, `formatOrderSize` and
+ * the standalone `millify`. Each `legacy*` function below is the implementation
+ * as it stood before the delegation, kept here as the oracle: the delegate must
+ * reproduce it over the whole corpus except at the cases listed in that
+ * member's diff table, and every entry in a diff table names the behaviour it
+ * is there for.
+ */
+
+const LOCALE = 'en';
+
+const legacyToTradePrecision = (num: number) => parseFloat(num.toPrecision(6));
+
+const legacyToTradePrecisionString = (
+	num: number,
+	toLocaleString?: boolean
+) => {
+	if (num === 0)
+		return Number(0).toLocaleString(LOCALE, {
+			minimumSignificantDigits: 6,
+			maximumSignificantDigits: 6,
+		});
+
+	const trimAmount = Math.abs(
+		num >= 1 || num === 0
+			? 0
+			: Math.min(0, Math.floor(Math.log10(Math.abs(num))))
+	);
+
+	const sigFigs = Math.max(Math.min(6 - trimAmount, 6), 1);
+
+	const tradePrecisionString = num.toPrecision(sigFigs);
+
+	if (toLocaleString)
+		return legacyToTradePrecision(num).toLocaleString(LOCALE, {
+			minimumSignificantDigits: sigFigs,
+			maximumSignificantDigits: sigFigs,
+		});
+
+	return tradePrecisionString;
+};
+
+const legacyToNotionalDisplay = (num: number) => {
+	return `${num < 0 ? `-` : ``}$${(
+		Math.round(Math.abs(num) * 100) / 100
+	).toLocaleString(LOCALE, {
+		maximumFractionDigits: 2,
+		minimumFractionDigits: 2,
+	})}`;
+};
+
+const legacyToBaseDisplay = (
+	baseAmount: number,
+	assetPrice?: number,
+	skipLocaleFormatting = false,
+	customSigFigs = 5
+): string => {
+	if (baseAmount < 1) {
+		if (baseAmount === 0) return '0.0000';
+
+		if (baseAmount < 0.00001) {
+			return '<0.00001';
+		}
+
+		return baseAmount.toFixed(4);
+	}
+	if (skipLocaleFormatting) {
+		return baseAmount.toFixed(
+			Math.min(
+				Math.max(0, Math.floor(Math.log10((assetPrice ?? 0) + 1))) + 2,
+				6
+			)
+		);
+	}
+
+	return baseAmount.toLocaleString(LOCALE, {
+		minimumSignificantDigits: customSigFigs,
+		maximumSignificantDigits: customSigFigs,
+	});
+};
+
+const legacyToDisplayPrice = (assetPrice: number): string => {
+	if (assetPrice === undefined) return '';
+	if (assetPrice === 0) return assetPrice.toFixed(2);
+
+	return assetPrice.toLocaleString(LOCALE, {
+		maximumSignificantDigits: 6,
+		minimumSignificantDigits: 6,
+	});
+};
+
+const legacyToPrice = (assetPrice: number): number => {
+	if (assetPrice === undefined) return 0;
+	if (assetPrice === 0) return parseFloat(assetPrice.toFixed(2));
+
+	return parseFloat(assetPrice.toFixed(6));
+};
+
+const legacyToDecimalPlaces = (
+	num: number,
+	decimalPlaces: number,
+	noPadding?: boolean
+): string => {
+	const truncatedNum =
+		Math.floor(num * Math.pow(10, decimalPlaces)) / Math.pow(10, decimalPlaces);
+	if (noPadding) {
+		return truncatedNum.toString();
+	}
+
+	const paddedNum = truncatedNum.toString();
+	const [integerPart, decimalPart = ''] = paddedNum.split('.');
+	const paddedDecimal = decimalPart.padEnd(decimalPlaces, '0');
+	return `${integerPart}.${paddedDecimal}`;
+};
+
+interface MillifyResult {
+	mantissa: number;
+	symbol: string;
+	sigFigs: number;
+	displayValue: number;
+	displayString: string;
+}
+
+const legacyNumLibMillify = (value: number): MillifyResult => {
+	if (!value)
+		return {
+			mantissa: 0,
+			symbol: '',
+			sigFigs: 1,
+			displayValue: 0,
+			displayString: '0',
+		};
+
+	const valueLog10 = Math.log10(value);
+
+	const metricAmount = Math.floor(valueLog10 / 3);
+
+	const sigFigs = Math.max(3 + (valueLog10 % 3), 1);
+
+	let symbol = '';
+	let mantissa = 1;
+
+	switch (metricAmount) {
+		case 1:
+			mantissa = 10 ** 3;
+			symbol = 'K';
+			break;
+		case 2:
+			mantissa = 10 ** 6;
+			symbol = 'M';
+			break;
+		case 3:
+			mantissa = 10 ** 9;
+			symbol = 'B';
+			break;
+		case 4:
+			mantissa = 10 ** 12;
+			symbol = 'T';
+			break;
+		case 0:
+		default:
+			mantissa = 1;
+			symbol = '';
+			break;
+	}
+
+	const displayValue = parseFloat(
+		(value / mantissa).toLocaleString(LOCALE, {
+			maximumSignificantDigits: sigFigs,
+		})
+	);
+
+	const displayString = `${(value / mantissa).toLocaleString(LOCALE, {
+		maximumSignificantDigits: sigFigs,
+	})}${symbol}`;
+
+	return { mantissa, symbol, sigFigs, displayValue, displayString };
+};
+
+/** Every field, so a change to the object shape shows up as a divergence too. */
+const showMillifyResult = (result: MillifyResult) =>
+	[
+		result.mantissa,
+		result.symbol,
+		result.sigFigs,
+		result.displayValue,
+		result.displayString,
+	].join('|');
+
+interface MillifyOptions {
+	precision?: number;
+	decimals?: number;
+	notation?: 'scientific' | 'financial';
+	trimEndingZeroes?: boolean;
+}
+
+const FINANCIAL_UNITS = ['', 'K', 'M', 'B', 'T', 'Q'];
+const SCIENTIFIC_UNITS = ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
+
+const legacyMillify = (value: number, options?: MillifyOptions): string => {
+	const precision = options?.precision ?? 6;
+	const trimEndingZeroes = options?.trimEndingZeroes ?? false;
+
+	if (isNaN(value)) return '0';
+
+	const isNegative = value < 0;
+	const absoluteValue = Math.abs(value);
+
+	const units =
+		(options?.notation ?? 'financial') === 'financial'
+			? FINANCIAL_UNITS
+			: SCIENTIFIC_UNITS;
+
+	if (absoluteValue < 1000) {
+		const formattedValue = absoluteValue.toPrecision(precision);
+		const trimmedValue = trimEndingZeroes
+			? parseFloat(formattedValue).toString()
+			: formattedValue;
+		return `${isNegative ? '-' : ''}${trimmedValue}`;
+	}
+
+	const unitIndex = Math.min(
+		Math.floor(Math.log10(absoluteValue) / 3),
+		units.length - 1
+	);
+
+	const scaledValue = absoluteValue / Math.pow(1000, unitIndex);
+	const valueWithDecimals =
+		options?.decimals !== undefined
+			? scaledValue.toFixed(options.decimals)
+			: scaledValue.toPrecision(precision);
+
+	const trimmedValue = trimEndingZeroes
+		? parseFloat(valueWithDecimals).toString()
+		: valueWithDecimals;
+
+	return `${isNegative ? '-' : ''}${trimmedValue}${units[unitIndex]}`;
+};
+
+const legacyFormatOrderSize = (
+	orderAmount: BigNum,
+	formatFn?: (amount: BigNum) => string
+): string => {
+	if (isEntirePositionOrder(orderAmount)) {
+		return 'Entire Position';
+	}
+	return formatFn ? formatFn(orderAmount) : orderAmount.prettyPrint();
+};
+
+// ---------------------------------------------------------------------------
+// The shared value corpus
+// ---------------------------------------------------------------------------
+
+const VALUES: [string, number][] = [
+	['0', 0],
+	['-0', -0],
+	['0.005', 0.005],
+	['-0.005', -0.005],
+	['0.05', 0.05],
+	['0.285', 0.285],
+	['0.2849', 0.2849],
+	['0.29', 0.29],
+	['-0.29', -0.29],
+	['0.5', 0.5],
+	['-0.5', -0.5],
+	['0.0000049', 0.0000049],
+	['-0.0000049', -0.0000049],
+	['0.0000051', 0.0000051],
+	['0.00001', 0.00001],
+	['1e-7', 1e-7],
+	['0.99999', 0.99999],
+	['0.999995', 0.999995],
+	['0.9999995', 0.9999995],
+	['1', 1],
+	['-1', -1],
+	['1.005', 1.005],
+	['1.23456789', 1.23456789],
+	['9.999999', 9.999999],
+	['9999.995', 9999.995],
+	['-9999.995', -9999.995],
+	['12345.6789', 12345.6789],
+	['1e6', 1e6],
+	['999999.5', 999999.5],
+	['-999999.5', -999999.5],
+	['999999999', 999999999],
+	['1e9', 1e9],
+	['1e12', 1e12],
+	['1e15', 1e15],
+	['1e21', 1e21],
+	['2^53', 2 ** 53],
+	['-2^53', -(2 ** 53)],
+	['NaN', NaN],
+	['Infinity', Infinity],
+	['-Infinity', -Infinity],
+	['undefined', undefined as unknown as number],
+	['null', null as unknown as number],
+];
+
+/** The magnitudes worth re-running for every extra parameter. */
+const SWEEP_KEYS = [
+	'0',
+	'0.5',
+	'-0.5',
+	'0.0000049',
+	'1.23456789',
+	'12345.6789',
+	'1e6',
+	'NaN',
+];
+
+const SWEEP_VALUES = VALUES.filter(([key]) => SWEEP_KEYS.includes(key));
+
+// ---------------------------------------------------------------------------
+// NumLib.formatNum.toTradePrecision
+// ---------------------------------------------------------------------------
+
+describe('NumLib.formatNum.toTradePrecision', () => {
+	const cases: CorpusCase[] = VALUES.map(([key, value]) => ({
+		key,
+		legacy: () => String(legacyToTradePrecision(value)),
+		next: () => String(NumLib.formatNum.toTradePrecision(value)),
+	}));
+
+	const divergences: Record<string, Divergence> = {};
+
+	it('agrees with the pre-delegation implementation', () => {
+		runCorpus(cases, divergences);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// NumLib.formatNum.toTradePrecisionString
+// ---------------------------------------------------------------------------
+
+describe('NumLib.formatNum.toTradePrecisionString', () => {
+	const cases: CorpusCase[] = [];
+	for (const [key, value] of VALUES) {
+		for (const toLocaleString of [undefined, true]) {
+			cases.push({
+				key: `${key}${toLocaleString ? ' localised' : ''}`,
+				legacy: () => legacyToTradePrecisionString(value, toLocaleString),
+				next: () =>
+					NumLib.formatNum.toTradePrecisionString(value, toLocaleString),
+			});
+		}
+	}
+
+	const divergences: Record<string, Divergence> = {};
+
+	it('agrees with the pre-delegation implementation', () => {
+		runCorpus(cases, divergences);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// NumLib.formatNum.toNotionalDisplay
+// ---------------------------------------------------------------------------
+
+describe('NumLib.formatNum.toNotionalDisplay', () => {
+	const cases: CorpusCase[] = VALUES.map(([key, value]) => ({
+		key,
+		legacy: () => legacyToNotionalDisplay(value),
+		next: () => NumLib.formatNum.toNotionalDisplay(value),
+	}));
+
+	const divergences: Record<string, Divergence> = {};
+
+	it('agrees with the pre-delegation implementation', () => {
+		runCorpus(cases, divergences);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// NumLib.formatNum.toBaseDisplay
+// ---------------------------------------------------------------------------
+
+describe('NumLib.formatNum.toBaseDisplay', () => {
+	const cases: CorpusCase[] = VALUES.map(([key, value]) => ({
+		key,
+		legacy: () => legacyToBaseDisplay(value),
+		next: () => NumLib.formatNum.toBaseDisplay(value),
+	}));
+
+	const PRICES: [string, number | undefined][] = [
+		['no price', undefined],
+		['price 0', 0],
+		['price 9', 9],
+		['price 10', 10],
+		['price 1234.56', 1234.56],
+	];
+
+	for (const [key, value] of SWEEP_VALUES) {
+		for (const [priceKey, price] of PRICES) {
+			cases.push({
+				key: `${key} raw ${priceKey}`,
+				legacy: () => legacyToBaseDisplay(value, price, true),
+				next: () => NumLib.formatNum.toBaseDisplay(value, price, true),
+			});
+		}
+		for (const sigFigs of [3, 8]) {
+			cases.push({
+				key: `${key} @${sigFigs}sf`,
+				legacy: () => legacyToBaseDisplay(value, undefined, false, sigFigs),
+				next: () =>
+					NumLib.formatNum.toBaseDisplay(value, undefined, false, sigFigs),
+			});
+		}
+	}
+
+	const divergences: Record<string, Divergence> = {};
+
+	it('agrees with the pre-delegation implementation', () => {
+		runCorpus(cases, divergences);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// NumLib.formatNum.toDisplayPrice
+// ---------------------------------------------------------------------------
+
+describe('NumLib.formatNum.toDisplayPrice', () => {
+	const cases: CorpusCase[] = VALUES.map(([key, value]) => ({
+		key,
+		legacy: () => legacyToDisplayPrice(value),
+		next: () => NumLib.formatNum.toDisplayPrice(value),
+	}));
+
+	const divergences: Record<string, Divergence> = {};
+
+	it('agrees with the pre-delegation implementation', () => {
+		runCorpus(cases, divergences);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// NumLib.formatNum.toPrice
+// ---------------------------------------------------------------------------
+
+describe('NumLib.formatNum.toPrice', () => {
+	const cases: CorpusCase[] = VALUES.map(([key, value]) => ({
+		key,
+		legacy: () => String(legacyToPrice(value)),
+		next: () => String(NumLib.formatNum.toPrice(value)),
+	}));
+
+	const divergences: Record<string, Divergence> = {};
+
+	it('agrees with the pre-delegation implementation', () => {
+		runCorpus(cases, divergences);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// NumLib.formatNum.toDecimalPlaces
+// ---------------------------------------------------------------------------
+
+describe('NumLib.formatNum.toDecimalPlaces', () => {
+	const cases: CorpusCase[] = [];
+	for (const [key, value] of VALUES) {
+		for (const noPadding of [false, true]) {
+			cases.push({
+				key: `${key} @2dp${noPadding ? ' unpadded' : ''}`,
+				legacy: () => legacyToDecimalPlaces(value, 2, noPadding),
+				next: () => NumLib.formatNum.toDecimalPlaces(value, 2, noPadding),
+			});
+		}
+	}
+	for (const [key, value] of SWEEP_VALUES) {
+		for (const decimalPlaces of [0, 4, 6]) {
+			cases.push({
+				key: `${key} @${decimalPlaces}dp`,
+				legacy: () => legacyToDecimalPlaces(value, decimalPlaces),
+				next: () => NumLib.formatNum.toDecimalPlaces(value, decimalPlaces),
+			});
+		}
+	}
+	for (const decimalPlaces of [-1, 1.5]) {
+		cases.push({
+			key: `1.23456789 @${decimalPlaces}dp`,
+			legacy: () => legacyToDecimalPlaces(1.23456789, decimalPlaces),
+			next: () => NumLib.formatNum.toDecimalPlaces(1.23456789, decimalPlaces),
+		});
+	}
+	// A value the float multiply lands just under, so the floor takes the
+	// neighbour below.
+	cases.push({
+		key: '1.005 @3dp',
+		legacy: () => legacyToDecimalPlaces(1.005, 3),
+		next: () => NumLib.formatNum.toDecimalPlaces(1.005, 3),
+	});
+
+	const divergences: Record<string, Divergence> = {};
+
+	it('agrees with the pre-delegation implementation', () => {
+		runCorpus(cases, divergences);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// NumLib.millify
+// ---------------------------------------------------------------------------
+
+describe('NumLib.millify', () => {
+	const cases: CorpusCase[] = VALUES.map(([key, value]) => ({
+		key,
+		legacy: () => showMillifyResult(legacyNumLibMillify(value)),
+		next: () => showMillifyResult(NumLib.millify(value)),
+	}));
+
+	const divergences: Record<string, Divergence> = {};
+
+	it('agrees with the pre-delegation implementation', () => {
+		runCorpus(cases, divergences);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// the standalone millify
+// ---------------------------------------------------------------------------
+
+describe('millify', () => {
+	const cases: CorpusCase[] = VALUES.map(([key, value]) => ({
+		key,
+		legacy: () => legacyMillify(value),
+		next: () => millify(value),
+	}));
+
+	const OPTIONS: [string, MillifyOptions][] = [
+		['3sf', { precision: 3 }],
+		['1dp', { decimals: 1 }],
+		['scientific', { notation: 'scientific' }],
+		['trimmed', { trimEndingZeroes: true }],
+	];
+
+	for (const [key, value] of SWEEP_VALUES) {
+		for (const [optionKey, options] of OPTIONS) {
+			cases.push({
+				key: `${key} ${optionKey}`,
+				legacy: () => legacyMillify(value, options),
+				next: () => millify(value, options),
+			});
+		}
+	}
+
+	const divergences: Record<string, Divergence> = {};
+
+	it('agrees with the pre-delegation implementation', () => {
+		runCorpus(cases, divergences);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// formatOrderSize
+// ---------------------------------------------------------------------------
+
+describe('formatOrderSize', () => {
+	const BASE = AMM_RESERVE_PRECISION_EXP;
+	const AMOUNTS: [string, () => BigNum][] = [
+		['0', () => BigNum.fromPrint('0', BASE)],
+		['1.5', () => BigNum.fromPrint('1.5', BASE)],
+		['-1.5', () => BigNum.fromPrint('-1.5', BASE)],
+		['1234.5678', () => BigNum.fromPrint('1234.5678', BASE)],
+		['0.000000001', () => BigNum.fromPrint('0.000000001', BASE)],
+		['1000000', () => BigNum.fromPrint('1000000', BASE)],
+		['max leverage', () => new BigNum(MAX_LEVERAGE_ORDER_SIZE, BASE)],
+		['truncated max', () => new BigNum(new BN('18446744072000000000'), BASE)],
+		[
+			'negative max leverage',
+			() => new BigNum(MAX_LEVERAGE_ORDER_SIZE.neg(), BASE),
+		],
+	];
+
+	const cases: CorpusCase[] = [];
+	for (const [key, amount] of AMOUNTS) {
+		cases.push({
+			key,
+			legacy: () => legacyFormatOrderSize(amount()),
+			next: () => formatOrderSize(amount()),
+		});
+		cases.push({
+			key: `${key} custom`,
+			legacy: () => legacyFormatOrderSize(amount(), (a) => a.toFixed(2)),
+			next: () => formatOrderSize(amount(), (a) => a.toFixed(2)),
+		});
+	}
+
+	const divergences: Record<string, Divergence> = {};
+
+	it('agrees with the pre-delegation implementation', () => {
+		runCorpus(cases, divergences);
+	});
+});

--- a/common-ts/tests/utils/numLibSetLocaleRatchet.test.ts
+++ b/common-ts/tests/utils/numLibSetLocaleRatchet.test.ts
@@ -11,9 +11,9 @@ const CANDIDATES = [
 const SRC = CANDIDATES.find((path) => existsSync(join(path, 'format', 'core')));
 
 /**
- * `NumLib.setLocale` still records a locale, but every display member now
- * renders through the format layer, which is en-US only. A call therefore reads
- * as a separator change and does nothing at all, so src may not make one.
+ * Every NumLib display member renders through the format layer, which is en-US
+ * only, so `NumLib.setLocale` keeps its signature and does nothing at all. A
+ * call reads as a separator change that never happens, so src may not make one.
  */
 const FORBIDDEN = new RegExp(
 	[

--- a/common-ts/tests/utils/numLibSetLocaleRatchet.test.ts
+++ b/common-ts/tests/utils/numLibSetLocaleRatchet.test.ts
@@ -1,0 +1,74 @@
+import { expect } from 'chai';
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative } from 'path';
+
+// Mocha loads this file as an ES module, so there is no __dirname to resolve
+// from. It runs from common-ts in both `bun run test` and CI.
+const CANDIDATES = [
+	join(process.cwd(), 'src'),
+	join(process.cwd(), 'common-ts', 'src'),
+];
+const SRC = CANDIDATES.find((path) => existsSync(join(path, 'format', 'core')));
+
+/**
+ * `NumLib.setLocale` still records a locale, but every display member now
+ * renders through the format layer, which is en-US only. A call therefore reads
+ * as a separator change and does nothing at all, so src may not make one.
+ */
+const FORBIDDEN = new RegExp(
+	[
+		String.raw`\bNumLib\s*(?:\?\.|\.)\s*setLocale\s*(?:\(|=(?!=))`,
+		String.raw`\bNumLib\s*(?:\?\.)?\s*\[\s*(['"])setLocale\1\s*\]`,
+	].join('|')
+);
+
+const hasForbiddenCall = (source: string) => FORBIDDEN.test(source);
+
+const sourceFiles = (dir: string): string[] =>
+	readdirSync(dir).flatMap((entry) => {
+		const path = join(dir, entry);
+		if (statSync(path).isDirectory()) return sourceFiles(path);
+		return path.endsWith('.ts') || path.endsWith('.tsx') ? [path] : [];
+	});
+
+describe('NumLib.setLocale ratchet', () => {
+	it('has no NumLib.setLocale call in common-ts src', () => {
+		expect(SRC, `could not find common-ts/src from ${process.cwd()}`).to.be.a(
+			'string'
+		);
+
+		const root = SRC as string;
+		const offenders = sourceFiles(root).flatMap((path) =>
+			hasForbiddenCall(readFileSync(path, 'utf8')) ? [relative(root, path)] : []
+		);
+
+		expect(
+			offenders,
+			'the format layer renders en-US only, so setting a locale changes nothing'
+		).to.deep.equal([]);
+	});
+
+	it('catches every shape the call can take', () => {
+		const caught = [
+			"NumLib.setLocale('de-DE');",
+			'NumLib?.setLocale("de-DE");',
+			"NumLib['setLocale']('de-DE');",
+			'NumLib.setLocale = () => {};',
+			'NumLib\n\t.setLocale(\n\t\t"de-DE"\n\t);',
+		];
+		for (const source of caught) {
+			expect(hasForbiddenCall(source), `missed: ${source}`).to.equal(true);
+		}
+
+		const allowed = [
+			'// never call NumLib.setLocale',
+			'const locale = NumLib.locale;',
+			'myNumLib.setLocale("de-DE");',
+		];
+		for (const source of allowed) {
+			expect(hasForbiddenCall(source), `false positive: ${source}`).to.equal(
+				false
+			);
+		}
+	});
+});


### PR DESCRIPTION
`NumLib` still formatted numbers on its own, next to a format layer that does the same
job exactly. This turns every display member into a thin deprecated delegate over
`formatText` / `formatValue`, and first promotes the option objects the trading UI holds
locally into `PRESETS` so both sides read from one definition.

Three commits: the characterization corpus that pins today's output, the presets, then the
delegation with every divergence declared.

## New presets

| Preset | Shape | Replaces |
| --- | --- | --- |
| `displayPrice` | 6 significant, half-up, grouped, zero sentinel rendering `0.00` | `PRICE_DISPLAY_SPEC` (`ui/src/utils/formatSpecs.ts`) |
| `priceText` | 6 significant, half-up, `trimTrailingZeros`, ungrouped | `TRADE_PRICE_TEXT_SPEC` |
| `tradePrecisionHalfUp` | 6 significant, `maxDecimals: 5`, half-up, ungrouped | the rounded twin of `tradePrecision`, which truncates |
| `baseAmount` | 5 significant, `maxDecimals: 4`, half-up, `small` sentinel at `0.00001` | `BASE_ASSET_AMOUNT_SPEC` |
| `earnBalance` | 4 decimals floored, `trimTrailingZeros`, ungrouped | `EARN_BALANCE_SPEC` |
| `millifiedAmount` | 2 decimals half-up, abbreviate from `1000`, 2-significant small form, `0` for zero and for unusable input | `MILLIFIED_AMOUNT_SPEC` |
| `specialValue` | exact digits, subscript small form, abbreviate at 7 integer digits with 6 significant half-up | `SPECIAL_VALUE_FORMAT` (`ui/src/utils/specialValueFormat.ts`) |

Each is deep-frozen like the rest of `PRESETS`, and `tests/format/tradingPresets.test.ts`
covers both the declared shape and representative output. The digits-only UI consts
(`PRICE_DIGITS`, `TRADE_PRECISION_DIGITS`) are not presets and were left where they are;
`PRICE_DIGITS` exists here only as a module-local const shared by `displayPrice` and
`priceText`.

## Delegation

| Member | Renders through | Adapter kept |
| --- | --- | --- |
| `NumLib.formatNum.toTradePrecision` | `PRESETS.priceText` + `parseFloat` | ungrouped text with `Infinity` spelled out, so `parseFloat` can read it back |
| `NumLib.formatNum.toTradePrecisionString` | `PRESETS.tradePrecisionHalfUp`, grouped when `toLocaleString` | none |
| `NumLib.formatNum.toNotionalDisplay` | `PRESETS.usdHalfUp` | none. It rounds the cent, where `BigNum.toNotional` truncates, and that is kept |
| `NumLib.formatNum.toBaseDisplay` | `PRESETS.baseAmount`, with `magnitude` digits on the `skipLocaleFormatting` path | from a magnitude of one upward the digits come from `customSigFigs` or the price; below one the preset's four decimals stand, whatever the caller asked for, as they did before |
| `NumLib.formatNum.toDisplayPrice` | `PRESETS.displayPrice` | none |
| `NumLib.formatNum.toPrice` | 6 decimals, half-up, `parseFloat` | the `undefined` guard returning `0`. Converts only, renders nothing |
| `NumLib.formatNum.toDecimalPlaces` | `decimals` + `rounding: 'floor'`, ungrouped, trimmed when `noPadding` | none |
| `NumLib.millify` | `PRESETS.millifiedAmount` | the returned object is rebuilt from `FormatResult` (`mantissa` from the abbreviation exponent, `sigFigs` from the digits rendered, `displayValue` zero when the result is text rather than digits) |
| `formatOrderSize` (`utils/trading/size.ts`) | `PRESETS.orderSize` | the `isEntirePositionOrder` check stays, because it also catches an amount a step size moved off the marker units, and it still guards the `formatFn` path |
| standalone `millify` (`utils/millify.ts`) | `formatText` with an `abbreviate` spec built from `precision` / `decimals` / `notation` / `trimEndingZeroes` | none |

Untouched: `sumBigNums`, `averageBigNums`, `toRawBn`, `toRawNum`, `formatBn.*`, `toBaseBN`,
`toQuoteBN`, `toNotionalNum`, `toBase`, `bp`, `isInvalid`. `getDisplayPrecision` gained a
doc note only: it reads a magnitude exponent off the raw BN string, counts the minus sign
as a digit, and must not be delegated to `marketPrecisionFromSizes`.

No display member reads a locale now, so `NumLib.setLocale` keeps its signature as a
deprecated no-op, the write-only private field behind it is gone, and a ratchet keeps
`src` free of calls to it, the way the `BigNum.setLocale` ratchet does.

## Behaviour changes

Every one of these is declared in `tests/utils/numLibDelegation.test.ts` against a frozen
copy of the old implementation. An undeclared disagreement fails the suite, and so does a
declared one that stops happening.

- **No zero padding below one.** `toDisplayPrice(0.5)` was `0.500000`, now `0.5`. Same for
  `toTradePrecisionString(0.5)` (`0.50000`), `toBaseDisplay(0.5)` (`0.5000`) and
  `millify(0.5)` (`0.500000`).
- **Non-finite renders as a symbol.** `toNotionalDisplay(NaN)` was `$NaN`, now `?`;
  `toNotionalDisplay(Infinity)` was `$∞`, now `∞`; `millify(Infinity)` was `InfinityQ`,
  now `∞`.
- **Nullish renders the fallback.** `toDisplayPrice(undefined)` was `''`, now `-`;
  `toDecimalPlaces(null, 2)` was `0.00`, now `-`; `toTradePrecision(undefined)` threw,
  now returns `NaN`. `toPrice(undefined)` still returns `0`.
- **Exact decimal ties.** `toNotionalDisplay(0.285)` was `$0.28`, now `$0.29`;
  `toNotionalDisplay(1.005)` was `$1.00`, now `$1.01`.
- **Digits from the exact decimal.** `toNotionalDisplay(1e21)` was
  `$999,999,999,999,999,900,000.00`, now `$1,000,000,000,000,000,000,000.00`. At
  `Number.MAX_VALUE` the old cent arithmetic overflowed to `$∞`, and the full 309 digits
  now render; `toDecimalPlaces(Number.MAX_VALUE, 2)` was `Infinity.00` for the same
  reason.
- **Exact floor.** `toDecimalPlaces(0.29, 2)` was `0.28`, now `0.29`;
  `toDecimalPlaces(1.005, 3)` was `1.004`, now `1.005`;
  `toDecimalPlaces(-9999.995, 4)` was `-9999.9951`, now `-9999.9950`. It still floors
  toward negative infinity, so `toDecimalPlaces(-0.5, 0)` is `-1`.
- **No exponent form.** `toTradePrecisionString(1e6)` was `1.00000e+6`, now `1000000`;
  `millify(1e-7)` was `1.00000e-7`, now `0.0000001`, and `1e-7` with
  `trimEndingZeroes: true` was `1e-7` for the same reason.
- **Digit count follows the rounded value.** `toTradePrecisionString(0.9999995)` was
  `1.0000`, now `1.00000`.
- **No digit credit below 1e-5.** `toTradePrecisionString(0.0000049)` was `0.000005`, now
  `0.00000`, because the six figures stop at five decimals.
- **Negatives keep their digits.** `toBaseDisplay` guarded on `baseAmount < 1` with no
  `abs()`, so every negative read `<0.00001`. `toBaseDisplay(-0.5)` is now `-0.5`,
  `toBaseDisplay(-0.0000049)` is `>-0.00001`, and `toBaseDisplay(-9999.995, 9, true)` is
  `-10000.00`. The guard reads the magnitude, so a negative takes the same digits as the
  positive of the same size.
- **The price-magnitude digits come from the price.** On the `skipLocaleFormatting` path
  the decimals were `log10(price + 1)`; they now read the price itself, matching `toBase`.
  `toBaseDisplay(1.23456789, 9, true)` was `1.235`, now `1.23`, and with no price it was
  `1.23`, now `1.234568`.
- **A custom significant count is still capped at four decimals**, from one upward:
  `toBaseDisplay(1.23456789, undefined, false, 8)` was `1.2345679`, now `1.2346`. Below
  one `customSigFigs` is ignored, as it was before, so `toBaseDisplay(0.12345, undefined,
  false, 3)` is still `0.1235`.
- **No dangling separator.** `toDecimalPlaces(1.23456789, 0)` was `1.`, now `1`.
- **An unusable decimalPlaces throws.** `toDecimalPlaces(x, -1)` and `toDecimalPlaces(x, 1.5)`
  returned float noise (`0.`, `1.2332882874656679`) and now throw, the way the input-path
  helpers do since #442.
- **`NumLib.millify`**: a nullish input reports `displayValue: 0` with the fallback dash
  as its `displayString`; the mantissa always carries two decimals (`1M` -> `1.00M`); the
  unit is re-derived after rounding (`999999.5` was `1,000K`, now `1.00M`); the units run
  past T (`1e15` was `1,000,000,000,000,000`, now `1.00Q`); a negative renders instead of
  throwing `RangeError: maximumSignificantDigits value is out of range` (`-1` is now
  `-1.00`); a value under a cent keeps two significant digits (`0.0000049` was `0.000005`,
  now `0.0000049`); `sigFigs` is the count of digits rendered rather than a fractional
  log (`1.23456789` was `3.0915149771692705`, now `3`); and an unusable value reports
  `mantissa: 1`, the identity, rather than `0`.
- **standalone `millify`**: `999999.5` was `1000.00K`, now `1.00000M`, from the same
  re-derived unit.

No consumer in the workspace calls the `NumLib` display members. The UI imports `NumLib`
from this package only for `sumBigNums`; the `NumLib.millify` calls in its vault tables
read the UI's own local `src/utils/NumLib`, not this one. The dashboard uses only
`abbreviateAddress` and the keeper bot only the `clients` subpath.

Two members do have live UI call sites on protocol-v2-mono `master`:

- `formatOrderSize`, from `ui/src/hooks/globalSyncs/accountSync/useExpiredOrderNotifications.ts`
  and `useTriggeredOrderNotifications.ts`, both on `order.baseAssetAmount`. Its corpus
  section is the one with no divergences at all: 18 cases over both the default and the
  `formatFn` path, including the two entire-position marker values and a negative one, all
  byte-identical.
- the standalone `millify`, from `Charts/InitialAssetWeightGraph.tsx`
  (`trimEndingZeroes: true`) and `Modals/FeeTierModal/consts.ts`
  (`decimals: 2, trimEndingZeroes: true`). Trimming hides the padding change, and the
  `decimals: 2` variant shows no diffs at all in the corpus. What the trimmed variant can
  see is the re-derived unit on a rounding carry (`999,999.5` reads `1M` rather than
  `1000K`) and `±Infinity` reading `∞` rather than `InfinityQ`.

## Verification

- `bun run test`: 668 passing.
- `tsc --noEmit` and `bun run build`: clean.
- `oxlint .` and `oxfmt --check`: clean.
- `madge --circular`: no cycles.
- `tests/format/bigNumParity.test.ts` and `tests/format/bigNumFuzz.test.ts` still pass, so
  the new presets do not disturb the BigNum parity sweep.

Every exported name and signature is unchanged.
