### PR TITLE
feat(common-ts): add the input field config and parser

### DIFF
--- a/common-ts/src/format/index.ts
+++ b/common-ts/src/format/index.ts
@@ -6,6 +6,7 @@ export {
 	Decimal,
 	DecimalStatus,
 	NumericInput,
+	ParseResult,
 	RawWithScale,
 	RoundingMode,
 	StepMode,
@@ -34,4 +35,12 @@ export {
 	snapValueToStep,
 	stepFractionDigits,
 } from './market';
+export {
+	DigitCaps,
+	InputFieldConfig,
+	InputFieldKind,
+	DIGIT_CAPS,
+	inputFieldConfig,
+	parseInput,
+} from './input';
 export { marketPrecisionFromAccount } from './adapters/sdk';

--- a/common-ts/src/format/input.ts
+++ b/common-ts/src/format/input.ts
@@ -1,0 +1,127 @@
+import {
+	Decimal,
+	MAX_EXPONENT_SHIFT,
+	ParseResult,
+	fromString,
+	roundToDecimals,
+} from './core/index';
+import { GROUP_SEPARATOR } from './locale';
+import { MarketPrecision } from './types';
+
+export type InputFieldKind =
+	| 'default'
+	| 'price'
+	| 'size'
+	| 'notional'
+	| 'slippage'
+	| 'orderCount'
+	| 'leverage';
+
+export interface DigitCaps {
+	maxIntegerDigits: number;
+	maxFractionDigits: number;
+}
+
+/**
+ * The typing caps for every field whose digits do not come from a market.
+ * `default`, `orderCount` and `slippage` reproduce the values the inputs
+ * hardcode today, so adopting them changes nothing a user can type.
+ */
+export const DIGIT_CAPS: Readonly<
+	Record<Exclude<InputFieldKind, 'price' | 'size'>, DigitCaps>
+> = Object.freeze({
+	default: Object.freeze({ maxIntegerDigits: 12, maxFractionDigits: 10 }),
+	/** Quote precision, so the mask and the outbound truncation agree. */
+	notional: Object.freeze({ maxIntegerDigits: 12, maxFractionDigits: 6 }),
+	/** Slippage is a percentage capped at 100, and 6 digits is a product call. */
+	slippage: Object.freeze({ maxIntegerDigits: 3, maxFractionDigits: 6 }),
+	/** Scaled orders top out at 32, and the fraction cap is the default's. */
+	orderCount: Object.freeze({ maxIntegerDigits: 2, maxFractionDigits: 10 }),
+	leverage: Object.freeze({ maxIntegerDigits: 3, maxFractionDigits: 2 }),
+});
+
+export interface InputFieldConfig {
+	/** Fed to the input mask. en-US only, so it is always 'en-US'. */
+	localeTag: string;
+	caps: DigitCaps;
+	/** The market lattice the submitted value must sit on. */
+	step?: Decimal;
+	/** Scale for parseInput, and the exponent the fixed-point value is built at. */
+	precisionExp?: number;
+}
+
+const LOCALE_TAG = 'en-US';
+
+/**
+ * One call supplies the mask's caps and the outbound truncation's step.
+ *
+ * `price` and `size` take their fraction cap, step and precision exponent from
+ * the market: the tick for a price, the step for a size. Without a market they
+ * fall back to the default caps and carry no step, so a field can render before
+ * market data arrives. A market passed for any other kind is ignored. Overrides
+ * win over both the table and the market.
+ */
+export function inputFieldConfig(
+	kind: InputFieldKind,
+	o?: { market?: MarketPrecision; overrides?: Partial<DigitCaps> }
+): InputFieldConfig {
+	const resolved = resolveCaps(kind, o?.market);
+	return {
+		localeTag: LOCALE_TAG,
+		...resolved,
+		caps: { ...resolved.caps, ...o?.overrides },
+	};
+}
+
+function resolveCaps(
+	kind: InputFieldKind,
+	market?: MarketPrecision
+): { caps: DigitCaps; step?: Decimal; precisionExp?: number } {
+	if (kind !== 'price' && kind !== 'size') return { caps: DIGIT_CAPS[kind] };
+	if (!market) return { caps: DIGIT_CAPS.default };
+	const step = kind === 'price' ? market.tick : market.step;
+	return {
+		caps: {
+			maxIntegerDigits: DIGIT_CAPS.default.maxIntegerDigits,
+			maxFractionDigits:
+				kind === 'price' ? market.priceDecimals : market.sizeDecimals,
+		},
+		step,
+		precisionExp: step.scale,
+	};
+}
+
+/** Empty, a sign on its own, or a separator the user typed first. */
+const NO_DIGITS_YET = /^[+-]?\.?$/;
+
+/**
+ * Reads what a user typed into a fixed-point value at `precisionExp`.
+ *
+ * Group separators are stripped before parsing, so the masked '1,234.5' and the
+ * bare '1234.5' agree. An in-progress '12.' parses as 12, exponent forms expand
+ * exactly, and fraction digits past `precisionExp` truncate toward zero, which
+ * is what the submit path does today. The result always carries scale
+ * `precisionExp`, so it feeds toFixedPointParts unchanged.
+ *
+ * A cleared or half-typed field ('', '  ', '-', '.') is `nullish`, distinct from
+ * the `invalid` a garbage string returns, and 'Infinity' keeps its own status.
+ */
+export function parseInput(input: string, precisionExp: number): ParseResult {
+	if (typeof input !== 'string') return { status: 'invalid', value: null };
+	if (
+		!Number.isInteger(precisionExp) ||
+		precisionExp < 0 ||
+		precisionExp > MAX_EXPONENT_SHIFT
+	) {
+		return { status: 'invalid', value: null };
+	}
+	const bare = input.split(GROUP_SEPARATOR).join('').trim();
+	if (NO_DIGITS_YET.test(bare)) return { status: 'nullish', value: null };
+
+	const parsed = fromString(bare);
+	if (parsed.status !== 'ok') return parsed;
+	return {
+		status: 'ok',
+		value: roundToDecimals(parsed.value, precisionExp, 'truncate'),
+	};
+}

--- a/common-ts/src/format/input.ts
+++ b/common-ts/src/format/input.ts
@@ -1,6 +1,5 @@
 import {
 	Decimal,
-	MAX_EXPONENT_SHIFT,
 	ParseResult,
 	fromString,
 	roundToDecimals,
@@ -8,6 +7,7 @@ import {
 import { GROUP_SEPARATOR } from './locale';
 import { MarketPrecision } from './types';
 
+/** Which field is being typed into, which is what its digit limits follow from. */
 export type InputFieldKind =
 	| 'default'
 	| 'price'
@@ -17,6 +17,7 @@ export type InputFieldKind =
 	| 'orderCount'
 	| 'leverage';
 
+/** How many digits the mask accepts on each side of the separator. */
 export interface DigitCaps {
 	maxIntegerDigits: number;
 	maxFractionDigits: number;
@@ -28,7 +29,7 @@ export interface DigitCaps {
  * hardcode today, so adopting them changes nothing a user can type.
  */
 export const DIGIT_CAPS: Readonly<
-	Record<Exclude<InputFieldKind, 'price' | 'size'>, DigitCaps>
+	Record<Exclude<InputFieldKind, 'price' | 'size'>, Readonly<DigitCaps>>
 > = Object.freeze({
 	default: Object.freeze({ maxIntegerDigits: 12, maxFractionDigits: 10 }),
 	/** Quote precision, so the mask and the outbound truncation agree. */
@@ -40,6 +41,7 @@ export const DIGIT_CAPS: Readonly<
 	leverage: Object.freeze({ maxIntegerDigits: 3, maxFractionDigits: 2 }),
 });
 
+/** Everything one input field needs: the mask's settings and the market lattice. */
 export interface InputFieldConfig {
 	/** Fed to the input mask. en-US only, so it is always 'en-US'. */
 	localeTag: string;
@@ -58,8 +60,16 @@ const LOCALE_TAG = 'en-US';
  * `price` and `size` take their fraction cap, step and precision exponent from
  * the market: the tick for a price, the step for a size. Without a market they
  * fall back to the default caps and carry no step, so a field can render before
- * market data arrives. A market passed for any other kind is ignored. Overrides
- * win over both the table and the market.
+ * market data arrives. A market passed for any other kind is ignored, and an
+ * unrecognised kind gets the default caps rather than a throw inside a render.
+ * Overrides win over both the table and the market, but only where they give a
+ * non-negative integer, so an unset prop cannot uncap a field.
+ *
+ * `precisionExp` for `size` is only as good as the `MarketPrecision` handed in.
+ * `marketPrecisionFromAccount` builds every step at base precision, which is
+ * right for a perp market; a spot market documents `orderStepSize` in its own
+ * decimals, so a spot field must supply a `MarketPrecision` built with the
+ * account's native decimals.
  */
 export function inputFieldConfig(
 	kind: InputFieldKind,
@@ -69,15 +79,33 @@ export function inputFieldConfig(
 	return {
 		localeTag: LOCALE_TAG,
 		...resolved,
-		caps: { ...resolved.caps, ...o?.overrides },
+		caps: mergeCaps(resolved.caps, o?.overrides),
 	};
+}
+
+function isDigitCount(value: unknown): value is number {
+	return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+function mergeCaps(
+	base: Readonly<DigitCaps>,
+	overrides?: Partial<DigitCaps>
+): DigitCaps {
+	const caps: DigitCaps = { ...base };
+	const integer = overrides?.maxIntegerDigits;
+	const fraction = overrides?.maxFractionDigits;
+	if (isDigitCount(integer)) caps.maxIntegerDigits = integer;
+	if (isDigitCount(fraction)) caps.maxFractionDigits = fraction;
+	return caps;
 }
 
 function resolveCaps(
 	kind: InputFieldKind,
 	market?: MarketPrecision
-): { caps: DigitCaps; step?: Decimal; precisionExp?: number } {
-	if (kind !== 'price' && kind !== 'size') return { caps: DIGIT_CAPS[kind] };
+): { caps: Readonly<DigitCaps>; step?: Decimal; precisionExp?: number } {
+	if (kind !== 'price' && kind !== 'size') {
+		return { caps: DIGIT_CAPS[kind] ?? DIGIT_CAPS.default };
+	}
 	if (!market) return { caps: DIGIT_CAPS.default };
 	const step = kind === 'price' ? market.tick : market.step;
 	return {
@@ -95,6 +123,12 @@ function resolveCaps(
 const NO_DIGITS_YET = /^[+-]?\.?$/;
 
 /**
+ * Well past every on-chain precision exponent (9 is the largest in use) and far
+ * short of a scale that would pad a value into an unrenderable digit string.
+ */
+const MAX_PRECISION_EXP = 30;
+
+/**
  * Reads what a user typed into a fixed-point value at `precisionExp`.
  *
  * Group separators are stripped before parsing, so the masked '1,234.5' and the
@@ -105,14 +139,11 @@ const NO_DIGITS_YET = /^[+-]?\.?$/;
  *
  * A cleared or half-typed field ('', '  ', '-', '.') is `nullish`, distinct from
  * the `invalid` a garbage string returns, and 'Infinity' keeps its own status.
+ * A `precisionExp` that is not a digit count, or is past 30, is `invalid` too.
  */
 export function parseInput(input: string, precisionExp: number): ParseResult {
 	if (typeof input !== 'string') return { status: 'invalid', value: null };
-	if (
-		!Number.isInteger(precisionExp) ||
-		precisionExp < 0 ||
-		precisionExp > MAX_EXPONENT_SHIFT
-	) {
+	if (!isDigitCount(precisionExp) || precisionExp > MAX_PRECISION_EXP) {
 		return { status: 'invalid', value: null };
 	}
 	const bare = input.split(GROUP_SEPARATOR).join('').trim();

--- a/common-ts/tests/format/input.test.ts
+++ b/common-ts/tests/format/input.test.ts
@@ -1,0 +1,285 @@
+import { expect } from 'chai';
+import {
+	DIGIT_CAPS,
+	InputFieldKind,
+	inputFieldConfig,
+	marketPrecisionFromSizes,
+	parseInput,
+} from '../../src/format/index';
+import { BN } from '@velocity-exchange/sdk';
+import { toPlainString } from '../../src/format/core/index';
+
+const QUOTE_EXP = 6;
+const BASE_EXP = 9;
+
+/** A cent tick and a milli-unit step, the shape of a live perp market. */
+const market = marketPrecisionFromSizes({
+	tickSize: new BN(10_000),
+	tickPrecisionExp: QUOTE_EXP,
+	stepSize: new BN(1_000_000),
+	stepPrecisionExp: BASE_EXP,
+});
+
+const parsed = (input: string, precisionExp: number) => {
+	const result = parseInput(input, precisionExp);
+	expect(result.status, input).to.equal('ok');
+	return toPlainString(result.value!);
+};
+
+describe('format/input digit caps', () => {
+	it('reproduces the caps the inputs hardcode today', () => {
+		expect(DIGIT_CAPS.default).to.deep.equal({
+			maxIntegerDigits: 12,
+			maxFractionDigits: 10,
+		});
+		expect(DIGIT_CAPS.orderCount).to.deep.equal({
+			maxIntegerDigits: 2,
+			maxFractionDigits: 10,
+		});
+		expect(DIGIT_CAPS.slippage).to.deep.equal({
+			maxIntegerDigits: 3,
+			maxFractionDigits: 6,
+		});
+	});
+
+	it('caps notional at quote precision and leverage at two decimals', () => {
+		expect(DIGIT_CAPS.notional).to.deep.equal({
+			maxIntegerDigits: 12,
+			maxFractionDigits: 6,
+		});
+		expect(DIGIT_CAPS.leverage).to.deep.equal({
+			maxIntegerDigits: 3,
+			maxFractionDigits: 2,
+		});
+	});
+
+	it('is frozen, so one field cannot retune another', () => {
+		expect(Object.isFrozen(DIGIT_CAPS)).to.equal(true);
+		expect(Object.isFrozen(DIGIT_CAPS.default)).to.equal(true);
+	});
+});
+
+describe('format/inputFieldConfig', () => {
+	const tableKinds = [
+		'default',
+		'notional',
+		'slippage',
+		'orderCount',
+		'leverage',
+	] as const;
+
+	it('returns the table caps and no market lattice for every table kind', () => {
+		for (const kind of tableKinds) {
+			const config = inputFieldConfig(kind);
+			expect(config.localeTag, kind).to.equal('en-US');
+			expect(config.caps, kind).to.deep.equal(DIGIT_CAPS[kind]);
+			expect(config.step, kind).to.equal(undefined);
+			expect(config.precisionExp, kind).to.equal(undefined);
+		}
+	});
+
+	it('ignores a market for a kind whose digits do not come from one', () => {
+		for (const kind of tableKinds) {
+			const config = inputFieldConfig(kind, { market });
+			expect(config.caps, kind).to.deep.equal(DIGIT_CAPS[kind]);
+			expect(config.step, kind).to.equal(undefined);
+			expect(config.precisionExp, kind).to.equal(undefined);
+		}
+	});
+
+	it('always reports the en-US tag, for every kind', () => {
+		const kinds: InputFieldKind[] = [...tableKinds, 'price', 'size'];
+		for (const kind of kinds) {
+			expect(inputFieldConfig(kind, { market }).localeTag).to.equal('en-US');
+		}
+	});
+
+	it('derives the price caps, step and precision exponent from the tick', () => {
+		const config = inputFieldConfig('price', { market });
+		expect(config.caps).to.deep.equal({
+			maxIntegerDigits: 12,
+			maxFractionDigits: 2,
+		});
+		expect(toPlainString(config.step!)).to.equal('0.010000');
+		expect(config.precisionExp).to.equal(QUOTE_EXP);
+	});
+
+	it('derives the size caps, step and precision exponent from the step', () => {
+		const config = inputFieldConfig('size', { market });
+		expect(config.caps).to.deep.equal({
+			maxIntegerDigits: 12,
+			maxFractionDigits: 3,
+		});
+		expect(toPlainString(config.step!)).to.equal('0.001000000');
+		expect(config.precisionExp).to.equal(BASE_EXP);
+	});
+
+	it('falls back to the default caps when no market is available yet', () => {
+		for (const kind of ['price', 'size'] as const) {
+			const config = inputFieldConfig(kind);
+			expect(config.caps, kind).to.deep.equal(DIGIT_CAPS.default);
+			expect(config.step, kind).to.equal(undefined);
+			expect(config.precisionExp, kind).to.equal(undefined);
+		}
+	});
+
+	it('keeps the full digit count of a step below 1e-6', () => {
+		const fine = marketPrecisionFromSizes({
+			tickSize: new BN(1),
+			tickPrecisionExp: QUOTE_EXP,
+			stepSize: new BN(100),
+			stepPrecisionExp: BASE_EXP,
+		});
+		expect(inputFieldConfig('price', { market: fine }).caps).to.deep.equal({
+			maxIntegerDigits: 12,
+			maxFractionDigits: 6,
+		});
+		const size = inputFieldConfig('size', { market: fine });
+		expect(size.caps.maxFractionDigits).to.equal(7);
+		expect(toPlainString(size.step!)).to.equal('0.000000100');
+		expect(size.precisionExp).to.equal(BASE_EXP);
+	});
+
+	it('reports zero fraction digits for a whole-unit step', () => {
+		const whole = marketPrecisionFromSizes({
+			tickSize: new BN(1_000_000),
+			tickPrecisionExp: QUOTE_EXP,
+			stepSize: new BN(1_000_000_000),
+			stepPrecisionExp: BASE_EXP,
+		});
+		const config = inputFieldConfig('size', { market: whole });
+		expect(config.caps.maxFractionDigits).to.equal(0);
+		expect(config.precisionExp).to.equal(BASE_EXP);
+		expect(inputFieldConfig('price', { market: whole }).caps).to.deep.equal({
+			maxIntegerDigits: 12,
+			maxFractionDigits: 0,
+		});
+	});
+
+	it('lets an override win over the table', () => {
+		const config = inputFieldConfig('slippage', {
+			overrides: { maxFractionDigits: 2 },
+		});
+		expect(config.caps).to.deep.equal({
+			maxIntegerDigits: 3,
+			maxFractionDigits: 2,
+		});
+	});
+
+	it('lets an override win over the market', () => {
+		const config = inputFieldConfig('price', {
+			market,
+			overrides: { maxIntegerDigits: 6, maxFractionDigits: 8 },
+		});
+		expect(config.caps).to.deep.equal({
+			maxIntegerDigits: 6,
+			maxFractionDigits: 8,
+		});
+		expect(config.precisionExp).to.equal(QUOTE_EXP);
+	});
+
+	it('does not hand out the table object itself', () => {
+		const config = inputFieldConfig('default');
+		config.caps.maxFractionDigits = 1;
+		expect(DIGIT_CAPS.default.maxFractionDigits).to.equal(10);
+	});
+});
+
+describe('format/parseInput', () => {
+	it('reads an empty or half-typed field as nullish', () => {
+		for (const input of ['', '   ', '-', '+', '.', '-.', ' . ']) {
+			const result = parseInput(input, 6);
+			expect(result.status, JSON.stringify(input)).to.equal('nullish');
+			expect(result.value, JSON.stringify(input)).to.equal(null);
+		}
+	});
+
+	it('accepts a grouped string, because the mask emits one', () => {
+		expect(parsed('1,234.5', 2)).to.equal('1234.50');
+		expect(parsed('1,234,567', 0)).to.equal('1234567');
+		expect(parsed('-1,000.25', 2)).to.equal('-1000.25');
+	});
+
+	// Separators are stripped, not validated, so a half-retyped field parses.
+	it('does not police where the group separators sit', () => {
+		expect(parsed('1,2,3', 0)).to.equal('123');
+		expect(parsed('1,', 0)).to.equal('1');
+	});
+
+	it('accepts an in-progress trailing separator and a leading one', () => {
+		expect(parsed('12.', 2)).to.equal('12.00');
+		expect(parsed('.5', 2)).to.equal('0.50');
+		expect(parsed('-.5', 2)).to.equal('-0.50');
+	});
+
+	it('keeps the sign, and reads -0 as zero', () => {
+		expect(parsed('-1.5', 2)).to.equal('-1.50');
+		const zero = parseInput('-0', 2);
+		expect(zero.status).to.equal('ok');
+		expect(toPlainString(zero.value!)).to.equal('0.00');
+	});
+
+	it('expands exponent forms exactly', () => {
+		expect(parsed('1e-9', 9)).to.equal('0.000000001');
+		expect(parsed('2.95e-7', 9)).to.equal('0.000000295');
+		expect(parsed('1e+21', 0)).to.equal('1000000000000000000000');
+		expect(parsed('1E3', 2)).to.equal('1000.00');
+	});
+
+	it('truncates toward zero past the precision exponent', () => {
+		expect(parsed('1.23456789', 4)).to.equal('1.2345');
+		expect(parsed('-1.23456789', 4)).to.equal('-1.2345');
+		expect(parsed('0.99999', 2)).to.equal('0.99');
+		expect(parsed('-0.0000001', 2)).to.equal('0.00');
+	});
+
+	it('leaves the digit caps to the mask and never clamps a value', () => {
+		expect(parsed('123456789012345678901234567890', 0)).to.equal(
+			'123456789012345678901234567890'
+		);
+		expect(parsed('999.999999', 6)).to.equal('999.999999');
+	});
+
+	it('always returns a value at exactly the requested scale', () => {
+		for (const exp of [0, 2, 6, 9]) {
+			const result = parseInput('7.5', exp);
+			expect(result.status).to.equal('ok');
+			const fraction = toPlainString(result.value!).split('.')[1] ?? '';
+			expect(fraction.length, `scale ${exp}`).to.equal(exp);
+		}
+	});
+
+	it('gives an infinity its own status, and the sign with it', () => {
+		const positive = parseInput('Infinity', 6);
+		expect(positive.status).to.equal('non-finite');
+		expect(
+			positive.status === 'non-finite' ? positive.nonFiniteSign : null
+		).to.equal(1);
+		const negative = parseInput('-Infinity', 6);
+		expect(negative.status).to.equal('non-finite');
+		expect(
+			negative.status === 'non-finite' ? negative.nonFiniteSign : null
+		).to.equal(-1);
+	});
+
+	it('rejects text that is not a number', () => {
+		for (const input of ['NaN', 'abc', '1 000', '1.2.3', '--1', '0x10', '1e']) {
+			const result = parseInput(input, 6);
+			expect(result.status, input).to.equal('invalid');
+			expect(result.value, input).to.equal(null);
+		}
+	});
+
+	it('rejects a precision exponent that is not a digit count', () => {
+		for (const exp of [-1, 1.5, NaN, 10_001]) {
+			expect(parseInput('1.5', exp).status, String(exp)).to.equal('invalid');
+		}
+	});
+
+	it('parses what inputFieldConfig says the field submits', () => {
+		const price = inputFieldConfig('price', { market });
+		expect(parsed('1,234.567', price.precisionExp!)).to.equal('1234.567000');
+		const size = inputFieldConfig('size', { market });
+		expect(parsed('0.0019999', size.precisionExp!)).to.equal('0.001999900');
+	});
+});

--- a/common-ts/tests/format/input.test.ts
+++ b/common-ts/tests/format/input.test.ts
@@ -178,6 +178,33 @@ describe('format/inputFieldConfig', () => {
 		expect(config.precisionExp).to.equal(QUOTE_EXP);
 	});
 
+	it('ignores an override the caller left unset', () => {
+		const config = inputFieldConfig('price', {
+			market,
+			overrides: { maxFractionDigits: undefined },
+		});
+		expect(config.caps).to.deep.equal({
+			maxIntegerDigits: 12,
+			maxFractionDigits: 2,
+		});
+	});
+
+	it('ignores an override that is not a digit count', () => {
+		for (const bad of [-3, 2.5, NaN, undefined]) {
+			const config = inputFieldConfig('slippage', {
+				overrides: { maxFractionDigits: bad, maxIntegerDigits: bad },
+			});
+			expect(config.caps, String(bad)).to.deep.equal(DIGIT_CAPS.slippage);
+		}
+	});
+
+	it('caps an unrecognised kind rather than throwing inside a render', () => {
+		const config = inputFieldConfig('spooky' as InputFieldKind);
+		expect(config.caps).to.deep.equal(DIGIT_CAPS.default);
+		expect(config.localeTag).to.equal('en-US');
+		expect(config.step).to.equal(undefined);
+	});
+
 	it('does not hand out the table object itself', () => {
 		const config = inputFieldConfig('default');
 		config.caps.maxFractionDigits = 1;
@@ -271,9 +298,10 @@ describe('format/parseInput', () => {
 	});
 
 	it('rejects a precision exponent that is not a digit count', () => {
-		for (const exp of [-1, 1.5, NaN, 10_001]) {
+		for (const exp of [-1, 1.5, NaN, 31]) {
 			expect(parseInput('1.5', exp).status, String(exp)).to.equal('invalid');
 		}
+		expect(parseInput('1.5', 30).status).to.equal('ok');
 	});
 
 	it('parses what inputFieldConfig says the field submits', () => {

--- a/common-ts/tests/format/properties.test.ts
+++ b/common-ts/tests/format/properties.test.ts
@@ -3,6 +3,7 @@ import {
 	PRESETS,
 	capStringFractionDigits,
 	formatText,
+	parseInput,
 	snapValueToStep,
 } from '../../src/format/index';
 import {
@@ -106,6 +107,39 @@ describe('format properties: parse and render round-trip', () => {
 			const value = randomDecimal(random);
 			const text = formatText(value, PRESETS.plain);
 			expect(fromString(text).value, text).to.deep.equal(value);
+		}
+	});
+});
+
+describe('format properties: input round-trip', () => {
+	it('parseInput(toPlainString(x)) reproduces x at its own scale', () => {
+		const random = makeRandom(SEED);
+		for (const raw of CORPUS) {
+			const value = toDecimal(raw).value!;
+			const back = parseInput(toPlainString(value), value.scale);
+			expect(back.status, raw).to.equal('ok');
+			expect(back.value, raw).to.deep.equal(value);
+		}
+		for (let i = 0; i < CASES; i++) {
+			const value = randomDecimal(random);
+			const text = toPlainString(value);
+			const back = parseInput(text, value.scale);
+			expect(back.status, text).to.equal('ok');
+			expect(back.value, text).to.deep.equal(value);
+		}
+	});
+
+	it('parseInput reads a grouped render back exactly', () => {
+		const random = makeRandom(SEED);
+		for (let i = 0; i < CASES; i++) {
+			const value = randomDecimal(random);
+			const text = formatText(value, {
+				digits: { kind: 'exact' },
+				grouping: true,
+			});
+			const back = parseInput(text, value.scale);
+			expect(back.status, text).to.equal('ok');
+			expect(back.value, text).to.deep.equal(value);
 		}
 	});
 });

--- a/common-ts/tests/format/surface.test.ts
+++ b/common-ts/tests/format/surface.test.ts
@@ -1,0 +1,35 @@
+import { expect } from 'chai';
+import * as format from '../../src/format/index';
+
+/**
+ * Every runtime name the ./format subpath publishes. Downstream apps import
+ * these, so a name only leaves the list with a migration.
+ */
+const PUBLIC_SURFACE = [
+	'DIGIT_CAPS',
+	'ENTIRE_POSITION',
+	'PRESETS',
+	'belowThreshold',
+	'capStringFractionDigits',
+	'formatText',
+	'formatValue',
+	'inputFieldConfig',
+	'isExactMultiple',
+	'marketPrecisionFromAccount',
+	'marketPrecisionFromSizes',
+	'optionsForLegacyType',
+	'parseInput',
+	'snapValueToStep',
+	'stepFractionDigits',
+];
+
+describe('format public surface', () => {
+	it('exports exactly the published names', () => {
+		expect(Object.keys(format).sort()).to.deep.equal(PUBLIC_SURFACE);
+	});
+
+	it('exports 15 runtime names', () => {
+		expect(Object.keys(format)).to.have.lengthOf(PUBLIC_SURFACE.length);
+		expect(PUBLIC_SURFACE).to.have.lengthOf(15);
+	});
+});

--- a/common-ts/tests/format/surface.test.ts
+++ b/common-ts/tests/format/surface.test.ts
@@ -3,7 +3,8 @@ import * as format from '../../src/format/index';
 
 /**
  * Every runtime name the ./format subpath publishes. Downstream apps import
- * these, so a name only leaves the list with a migration.
+ * these, so a name only leaves the list with a migration. Type-only exports
+ * erase before this runs and are not pinned here.
  */
 const PUBLIC_SURFACE = [
 	'DIGIT_CAPS',
@@ -26,10 +27,5 @@ const PUBLIC_SURFACE = [
 describe('format public surface', () => {
 	it('exports exactly the published names', () => {
 		expect(Object.keys(format).sort()).to.deep.equal(PUBLIC_SURFACE);
-	});
-
-	it('exports 15 runtime names', () => {
-		expect(Object.keys(format)).to.have.lengthOf(PUBLIC_SURFACE.length);
-		expect(PUBLIC_SURFACE).to.have.lengthOf(15);
 	});
 });


### PR DESCRIPTION
Adds the input-field half of the number-formatting input path to `@velocity-exchange/common/format`. Nothing adopts it yet, so nothing in the package changes behaviour today.

## Surface added

```ts
export type InputFieldKind =
  | 'default' | 'price' | 'size' | 'notional' | 'slippage' | 'orderCount' | 'leverage';

export interface DigitCaps { maxIntegerDigits: number; maxFractionDigits: number }
export const DIGIT_CAPS: Readonly<Record<Exclude<InputFieldKind, 'price' | 'size'>, Readonly<DigitCaps>>>;

export interface InputFieldConfig {
  localeTag: string;   // always 'en-US', fed to @react-input/number-format
  caps: DigitCaps;
  step?: Decimal;
  precisionExp?: number;
}
export function inputFieldConfig(
  kind: InputFieldKind,
  o?: { market?: MarketPrecision; overrides?: Partial<DigitCaps> }
): InputFieldConfig;

export function parseInput(input: string, precisionExp: number): ParseResult;
```

`ParseResult` is now re-exported from the subpath, because `parseInput` returns it.

### `DIGIT_CAPS`

| kind | maxIntegerDigits | maxFractionDigits | why |
| --- | --- | --- | --- |
| `default` | 12 | 10 | what `useNumberInput` hardcodes today |
| `notional` | 12 | 6 | quote precision, so the mask and the outbound truncation agree |
| `slippage` | 3 | 6 | what `ControlledSlippageToleranceInput` hardcodes today |
| `orderCount` | 2 | 10 | what `ScaledOrderCountInput` hardcodes today, fraction inherited from the default |
| `leverage` | 3 | 2 | new field, no current input to preserve |

The three kinds that exist in the UI today carry the UI's current values, so adopting them changes nothing a user can type. `notional` and `leverage` have no current input to match and are new product choices.

### What `price` and `size` derive

Both read `MarketPrecision`: `price` from the tick, `size` from the step.

- `caps.maxIntegerDigits`: the default's 12.
- `caps.maxFractionDigits`: `market.priceDecimals` / `market.sizeDecimals`, which are the tick's / step's own fraction-digit counts, so a step of `1e-7` gives 7 digits rather than the zero its JS stringification implies.
- `step`: `market.tick` / `market.step`, the lattice the submitted value must sit on.
- `precisionExp`: the tick's / step's scale, which is the on-chain precision exponent (6 for a price, 9 for a perp base size), so the same call supplies the exponent the fixed-point value is rebuilt at.

Without a market, `price` and `size` fall back to the default caps and carry no step or exponent, so a field can render before market data arrives. A market passed for any other kind is ignored, and an unrecognised kind gets the default caps rather than throwing inside a render. Overrides win over both the table and the market derivation, but only where they give a non-negative integer, so `overrides: { maxFractionDigits: props.maxDecimals }` with an unset prop leaves the field capped instead of uncapping it.

## `parseInput` semantics

Reads what a user typed into an exact `Decimal` at `precisionExp`. The result always carries scale `precisionExp`, so it feeds `toFixedPointParts` unchanged.

| input | `precisionExp` | result |
| --- | --- | --- |
| `''`, `'   '`, `'-'`, `'.'` | any | `nullish`: the field is cleared or has no digits yet |
| `'1,234.5'` | 2 | ok, `1234.50`. Group separators are stripped, because the mask emits them |
| `'12.'` | 2 | ok, `12.00`. An in-progress trailing separator is accepted |
| `'.5'` | 2 | ok, `0.50` |
| `'-0'` | 2 | ok, `0.00`. Negative zero is zero |
| `'2.95e-7'` | 9 | ok, `0.000000295`. Exponent forms expand exactly, both `e-` and `e+` |
| `'1.23456789'` | 4 | ok, `1.2345`. Digits past the exponent truncate toward zero |
| `'Infinity'` | any | `non-finite`, with the sign |
| `'NaN'`, `'abc'`, `'1 000'` | any | `invalid` |
| anything | `-1`, `1.5`, `31` | `invalid`. The exponent must be a digit count, and 30 is the bound |

`nullish` is deliberately distinct from `invalid`, so a cleared field and a corrupt one no longer look the same to a caller. `parseInput` does not enforce `DIGIT_CAPS`: the caps are the mask's job and a value is never clamped on the way in.

## Divergences from `BigNum.fromPrint`

`parseInput` is the replacement for `BigNum.fromPrint` at input boundaries, so every difference below becomes a behaviour change when a call site adopts it. Reproduced against the installed SDK at `precisionExp` 6, rendering both sides with their own printer.

| input | `parseInput` | `BigNum.fromPrint` |
| --- | --- | --- |
| `''`, `'  '`, `'.'` | `nullish` | `0.000000` |
| `'-'`, `'-.'` | `nullish` | throws |
| `' 1.5 '`, `'1.5 '` | `1.500000` | `0.150000` |
| `'1 .5'` | `invalid` | `1.500000` |
| `'1.2.3'` | `invalid` | `1.200000` |
| `'1,234.5'` | `1234.500000` | throws |
| `'+5'` | `5.000000` | throws |
| `'Infinity'` | `non-finite` | throws |
| `'1e21'` | `1000000000000000000000.000000` | throws |
| `'1.9999999e0'` | `1.999999` | `2.000000` |
| `'9.999999e-1'` | `0.999999` | `1.000000` |
| `'8.7e-7'` | `0.000000` | `0.000001` |
| `'-1.9999999e0'` | `-1.999999` | `-2.000000` |

Most rows are `fromPrint` bugs the new parser declines to reproduce: it strips whitespace on the left only, so a trailing space silently moves the decimal point a place left; it splits on the first separator and keeps typing after a second one; and it rejects the grouped string its own mask produces.

Two rows are user-visible at adoption and need a decision per call site:

- **Empty and partial input is `nullish`, not zero.** Any caller relying on `fromPrint('')` returning zero has to map `nullish` itself, which is the point: a cleared field and a typed zero stop looking the same.
- **Exponent forms round in `fromPrint` and truncate here.** `fromPrint` routes an `e` string through `(+val).toFixed(precision)`, which rounds half away from zero, while every other path in it truncates. `parseInput` truncates toward zero on both signs, consistently.

## Known limitation

`inputFieldConfig('size').precisionExp` is only as good as the `MarketPrecision` it is handed. `adapters/sdk.ts` builds every step at `BASE_PRECISION_EXP` (9), which is right for a perp market, but the SDK documents a spot market's `orderStepSize` in that market's native decimals. Until now the mismatch only skewed a display digit count; `precisionExp` promotes it to the exponent a submitted value is built at, so a 6-decimal spot market would be told 9. `adapters/sdk.ts` is deliberately untouched here, and the JSDoc on `inputFieldConfig` records the caveat. This has to be settled before any spot input adopts the config.

## Behaviour changes

No existing export changes: `src/format/index.ts` gains six names and `ParseResult`, and removes or renames nothing. Nothing in the package calls the new functions yet, so no current output moves. The divergences above land when the UI adopts them, one call site at a time.

## Tests

- `tests/format/input.test.ts`: the `DIGIT_CAPS` values and their freezing; `inputFieldConfig` for every kind with and without a market; a market ignored for a table kind; an unrecognised kind; override precedence over both the table and the market; overrides that are unset, negative, fractional or `NaN` being ignored; `price` and `size` derived from a `marketPrecisionFromSizes` market, including a tick and step below `1e-6` and a whole-unit step with zero fraction digits; and the `parseInput` rows above, exponent bound included.
- `tests/format/properties.test.ts`: two new properties, `parseInput(toPlainString(x))` and `parseInput(grouped render of x)` reproducing `x` at its own scale, over the shared corpus plus 400 random values. The `capStringFractionDigits` and `snapValueToStep` properties the test strategy asks for already exist in this file and are not duplicated.
- `tests/format/surface.test.ts`: pins the runtime names the `./format` subpath publishes.

## Checks

`bun run test` 701 passing, `bun run typecheck` clean, `bun run build` clean, `oxlint` clean, `oxfmt --check` clean, `bunx madge --circular` reports no cycles.